### PR TITLE
Oppdaterte eksempelfiler

### DIFF
--- a/eksempler/grunnleggende-ferdigheter/GF1.json
+++ b/eksempler/grunnleggende-ferdigheter/GF1.json
@@ -2,7 +2,7 @@
     "id": "uuid:ceba24a2-0501-11e9-8eb2-f2801f1b9fd1",
     "kode": "GF1",
     "uri": "http://psi.udir.no/kl06/GF1",
-    "url-data": "http://data.udir.no/kl06/GF1",
+    "url-data": "http://data.udir.no/kl06/v201906/grunnleggende-ferdigheter-lk20/GF1",
     "tittel": [
         {
             "spraak": "default",
@@ -10,26 +10,36 @@
         }
     ],
     "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
-    "status": "http://data.udir.no/kl06/status_publisert",
+    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
     "sist-endret": "2018-12-21T13:16:05.228885",
     "lenke-til-beskrivelse": "https://www.udir.no/laring-og-trivsel/lareplanverket/grunnleggende-ferdigheter/rammeverk-for-grunnleggende-ferdigheter/2.1-digitale-ferdigheter/",
     "laereplan-referanser": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "uuid:3c03c709-4934-4012-9353-c14bfa8ff651",
             "kode": "MAT1-05",
             "uri": "http://psi.udir.no/kl06/MAT1-05",
-            "url-data": "http://data.udir.no/kl06/MAT1-05",
+            "url-data": "http://data.udir.no/kl06/v201906/laereplaner-lk20/MAT1-05",
             "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
-            "status": "http://data.udir.no/kl06/status_publisert",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Matematikk fellesfag"
         }
     ],
     "kompetansemaal-referanser": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "uuid:cec30cd4-1fe6-11e9-8e78-d663bd873d93",
             "kode": "K1",
             "uri": "http://psi.udir.no/kl06/K1",
-            "url-data": "http://data.udir.no/kl06/K1",
+            "url-data": "http://data.udir.no/kl06/v201906/kompetansemaal-lk20/K1",
             "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-            "status": "http://data.udir.no/kl06/status_publisert",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "samanlikne ulike storleikar og mengder og uttrykkje dette gjennom eige språk og matematisk språk"
         }
     ]

--- a/eksempler/kjerneelementer/KE1.json
+++ b/eksempler/kjerneelementer/KE1.json
@@ -2,37 +2,60 @@
     "id": "uuid:d570dcc2-0381-11e9-8eb2-f2801f1b9fd1",
     "kode": "KE1",
     "uri": "http://psi.udir.no/kl06/KE1",
-    "url-data": "http://data.udir.no/kl06/KE1",
-    "tittel": [
-        {
-            "spraak": "default",
-            "verdi": "Utforsking og problemløysing"
-        }
-    ],
+    "url-data": "http://data.udir.no/kl06/v201906/kjerneelementer-lk20/KE1",
+    "tittel": {
+        "tekst": [
+            {
+                "spraak": "default",
+                "verdi": "Utforsking og problemløysing"
+            }
+        ],
+        "forskrift": true
+    },
     "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
-    "status": "http://data.udir.no/kl06/status_publisert",
+    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
     "sist-endret": "2018-12-19T13:16:05.228885",
-    "beskrivelse": [
+    "beskrivelse": {
+        "tekst": [
+            {
+                "spraak": "default",
+                "verdi": "Dette kjerneelementet er det viktigaste for faget og for høvet til djupnelæring. Dei andre kjerneelementa må sjåast i samanheng med dette. Utforsking handlar om at elevane leiter etter mønster og finn samanhengar. Det må leggjast meir vekt på ulike strategiar og framgangsmåtar enn på sjølve løysingane. Problemløysing handlar om at elevane utviklar løysingsmetodar på eit problem dei ikkje kjenner frå før. Algoritmisk tenking er viktig i prosessen med å utvikle strategiar og framgangsmåtar og inneber å kunne bryte ned eit problem i delproblem som kan løysast systematisk. Viktig innhald vil vere å kunne stille matematiske spørsmål og formulere matematiske problemstillingar, identifisere problem, vere uthaldande, utvikle og kunne velje effektive problemløysingsstrategiar og utforske og løyse problem ved hjelp av programmering. Elevane må få høve til å vere nysgjerrige, også på fagstoff som dei ikkje elles møter av matematikk på trinnet sitt."
+            }
+        ],
+        "forskrift": true
+    },
+    "rekkefoelge": 1,
+    "forklaring": [
         {
             "spraak": "default",
-            "verdi": "Dette kjerneelementet er det viktigaste for faget og for høvet til djupnelæring. Dei andre kjerneelementa må sjåast i samanheng med dette. Utforsking handlar om at elevane leiter etter mønster og finn samanhengar. Det må leggjast meir vekt på ulike strategiar og framgangsmåtar enn på sjølve løysingane. Problemløysing handlar om at elevane utviklar løysingsmetodar på eit problem dei ikkje kjenner frå før. Algoritmisk tenking er viktig i prosessen med å utvikle strategiar og framgangsmåtar og inneber å kunne bryte ned eit problem i delproblem som kan løysast systematisk. Viktig innhald vil vere å kunne stille matematiske spørsmål og formulere matematiske problemstillingar, identifisere problem, vere uthaldande, utvikle og kunne velje effektive problemløysingsstrategiar og utforske og løyse problem ved hjelp av programmering. Elevane må få høve til å vere nysgjerrige, også på fagstoff som dei ikkje elles møter av matematikk på trinnet sitt."
+            "verdi": "Forklaring på kjerneelement"
         }
     ],
     "tilhoerer-laereplan": {
+        "gyldighet": {
+            "gyldig-fra": null,
+            "gyldig-til": null
+        },
+        "id": "uuid:3c03c709-4934-4012-9353-c14bfa8ff651",
         "kode": "MAT1-05",
         "uri": "http://psi.udir.no/kl06/MAT1-05",
-        "url-data": "http://data.udir.no/kl06/MAT1-05",
+        "url-data": "http://data.udir.no/kl06/v201906/laereplaner-lk20/MAT1-05",
         "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
-        "status": "http://data.udir.no/kl06/status_publisert",
+        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
         "tittel": "Matematikk fellesfag"
     },
     "kompetansemaal-referanser": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "uuid:cec30cd4-1fe6-11e9-8e78-d663bd873d93",
             "kode": "K1",
             "uri": "http://psi.udir.no/kl06/K1",
-            "url-data": "http://data.udir.no/kl06/K1",
+            "url-data": "http://data.udir.no/kl06/v201906/kompetansemaal-lk20/K1",
             "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-            "status": "http://data.udir.no/kl06/status_publisert",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "samanlikne ulike storleikar og mengder og uttrykkje dette gjennom eige språk og matematisk språk"
         }
     ]

--- a/eksempler/kompetansemaal/K1.json
+++ b/eksempler/kompetansemaal/K1.json
@@ -2,82 +2,176 @@
     "id": "uuid:cec30cd4-1fe6-11e9-8e78-d663bd873d93",
     "kode": "K1",
     "uri": "http://psi.udir.no/kl06/K1",
-    "url-data": "http://data.udir.no/kl06/K1",
-    "tittel": [
+    "url-data": "http://data.udir.no/kl06/v201906/kompetansemaal-lk20/K1",
+    "tittel": {
+        "tekst": [
+            {
+                "spraak": "default",
+                "verdi": "samanlikne ulike storleikar og mengder og uttrykkje dette gjennom eige språk og matematisk språk"
+            }
+        ],
+        "forskrift": true
+    },
+    "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
+    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+    "sist-endret": "2018-12-12T13:16:05.228885",
+    "rekkefoelge": 1,
+    "forklaring": [
         {
             "spraak": "default",
-            "verdi": "samanlikne ulike storleikar og mengder og uttrykkje dette gjennom eige språk og matematisk språk"
+            "verdi": "Forklaring på kompetansemål"
         }
     ],
-    "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-    "status": "http://data.udir.no/kl06/status_publisert",
-    "sist-endret": "2018-12-12T13:16:05.228885",
     "tilknyttede-grunnleggende-ferdigheter": [
         {
-            "kode": "GF1",
-            "uri": "http://psi.udir.no/kl06/GF1",
-            "url-data": "http://data.udir.no/kl06/GF1",
-            "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
-            "tittel": "Digitale ferdigheter"
+            "referanse": {
+                "gyldighet": {
+                    "gyldig-fra": null,
+                    "gyldig-til": null
+                },
+                "id": "uuid:ceba24a2-0501-11e9-8eb2-f2801f1b9fd1",
+                "kode": "GF1",
+                "uri": "http://psi.udir.no/kl06/GF1",
+                "url-data": "http://data.udir.no/kl06/v201906/grunnleggende-ferdigheter-lk20/GF1",
+                "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
+                "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                "tittel": "Digitale ferdigheter"
+            },
+            "forklaring": [
+                {
+                    "spraak": "default",
+                    "verdi": "Forklaring på koplingen til grunnleggende ferdighet"
+                }
+            ]
         }
     ],
     "tilknyttede-tverrfaglige-tema": [
         {
-            "kode": "TT1",
-            "uri": "http://psi.udir.no/kl06/TT1",
-            "url-data": "http://data.udir.no/kl06/TT1",
-            "grep-type": "http://psi.udir.no/ontologi/kl06/tverrfaglig_tema_lk20",
-            "tittel": "Folkehelse og livsmestring"
+            "referanse": {
+                "gyldighet": {
+                    "gyldig-fra": null,
+                    "gyldig-til": null
+                },
+                "id": "uuid:c28b7650-0366-11e9-8eb2-f2801f1b9fd1",
+                "kode": "TT1",
+                "uri": "http://psi.udir.no/kl06/TT1",
+                "url-data": "http://data.udir.no/kl06/v201906/tverrfaglige-temaer-lk20/TT1",
+                "grep-type": "http://psi.udir.no/ontologi/kl06/tverrfaglig_tema_lk20",
+                "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                "tittel": "Folkehelse og livsmestring"
+            },
+            "forklaring": [
+                {
+                    "spraak": "default",
+                    "verdi": "Forklaring på koplingen til tverrfaglig tema"
+                }
+            ]
         }
     ],
     "tilknyttede-kjerneelementer": [
         {
-            "kode": "KE1",
-            "uri": "http://psi.udir.no/kl06/KE1",
-            "url-data": "http://data.udir.no/kl06/KE1",
-            "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
-            "tittel": "Utforsking og problemløysing"
+            "referanse": {
+                "gyldighet": {
+                    "gyldig-fra": null,
+                    "gyldig-til": null
+                },
+                "id": "uuid:d570dcc2-0381-11e9-8eb2-f2801f1b9fd1",
+                "kode": "KE1",
+                "uri": "http://psi.udir.no/kl06/KE1",
+                "url-data": "http://data.udir.no/kl06/v201906/kjerneelementer-lk20/KE1",
+                "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
+                "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                "tittel": "Utforsking og problemløysing"
+            },
+            "forklaring": [
+                {
+                    "spraak": "default",
+                    "verdi": "Forklaring på koplingen til kjerneelement"
+                }
+            ]
         }
     ],
     "tilknyttede-verb": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "uuid:859ec978-fd4d-11e8-8eb2-f2801f1b9fd1",
             "kode": "VERB14",
             "uri": "http://psi.udir.no/kl06/VERB14",
-            "url-data": "http://data.udir.no/kl06/VERB14",
+            "url-data": "http://data.udir.no/kl06/v201906/verb-lk20/VERB14",
             "grep-type": "http://psi.udir.no/ontologi/kl06/verb_lk20",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Sammenligne"
         }
     ],
     "bygger-paa": [
         {
-            "kode": "K3",
-            "uri": "http://psi.udir.no/kl06/K3",
-            "url-data": "http://data.udir.no/kl06/K3",
-            "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-            "tittel": "utforske og beskrive mengder og eigenskapar ved mengder og representere mengder på forskjellige måtar"
+            "referanse": {
+                "gyldighet": {
+                    "gyldig-fra": null,
+                    "gyldig-til": null
+                },
+                "id": "uuid:5624d0e8-2e2b-11e9-b210-d663bd873d93",
+                "kode": "K3",
+                "uri": "http://psi.udir.no/kl06/K3",
+                "url-data": "http://data.udir.no/kl06/v201906/kompetansemaal-lk20/K3",
+                "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
+                "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                "tittel": "utforske og beskrive mengder og eigenskapar ved mengder og representere mengder på forskjellige måtar"
+            },
+            "forklaring": [
+                {
+                    "spraak": "default",
+                    "verdi": "Forklaring på koplingen til kompetansemål"
+                }
+            ]
         }
     ],
     "samme-som": [
         {
-            "kode": "K1",
-            "uri": "http://psi.udir.no/kl06/K1",
-            "url-data": "http://data.udir.no/kl06/K1",
-            "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-            "tittel": "ordne og sortere gjenstandar ut frå ulike eigenskapar og diskutere om dette kan gjerast på fleire måtar"
+            "referanse": {
+                "id": "uuid:97d9dec0-2e2b-11e9-b210-d663bd873d93",
+                "kode": "K2",
+                "uri": "http://psi.udir.no/kl06/K2",
+                "url-data": "http://data.udir.no/kl06/v201906/kompetansemaal-lk20/K2",
+                "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
+                "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                "tittel": "ordne og sortere gjenstandar ut frå ulike eigenskapar og diskutere om dette kan gjerast på fleire måtar"
+            },
+            "forklaring": [
+                {
+                    "spraak": "default",
+                    "verdi": "Forklaring på koplingen til kompetansemål"
+                }
+            ]
         }
     ],
     "tilhoerer-laereplan": {
+        "gyldighet": {
+            "gyldig-fra": null,
+            "gyldig-til": null
+        },
+        "id": "uuid:3c03c709-4934-4012-9353-c14bfa8ff651",
         "kode": "MAT1-05",
         "uri": "http://psi.udir.no/kl06/MAT1-05",
-        "url-data": "http://data.udir.no/kl06/MAT1-05",
+        "url-data": "http://data.udir.no/kl06/v201906/laereplaner-lk20/MAT1-05",
         "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
+        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
         "tittel": "Matematikk fellesfag"
     },
     "tilhoerer-kompetansemaalsett": {
+        "gyldighet": {
+            "gyldig-fra": null,
+            "gyldig-til": null
+        },
+        "id": "uuid:129ca8c7-e839-4551-a2e2-9998f48f1f81",
         "kode": "KMS1",
         "uri": "http://psi.udir.no/kl06/KMS1",
-        "url-data": "http://ata.udir.no/kl06/KMS1",
+        "url-data": "http://data.udir.no/kl06/v201906/kompetansemaalsett-lk20/KMS1",
         "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaalsett_lk20",
+        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
         "tittel": "Kompetansemål og vurdering 2. trinn"
     }
 }

--- a/eksempler/kompetansemaalsett/KMS9.json
+++ b/eksempler/kompetansemaalsett/KMS9.json
@@ -2,112 +2,181 @@
     "id": "uuid:d0a1d4fd-cb72-4608-8269-39270144364b",
     "kode": "KMS9",
     "uri": "http://psi.udir.no/kl06/KMS9",
-    "url-data": "http://data.udir.no/kl06/KMS9",
-    "tittel": [
-        {
-            "spraak": "default",
-            "verdi": "Kompetansemål og vurdering 10. trinn"
-        }
-    ],
-    "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaalsett_lk20",
-    "status": "http://data.udir.no/kl06/status_publisert",
-    "sist-endret": "2018-12-12T13:16:05.228885",
-    "kortform": null,
-    "kompetansemaal-overskrift": [
-        {
-            "spraak": "default",
-            "verdi": "Kompetansemål etter 10. trinn"
-        }
-    ],
-    "kompetansemaal-ingress": [
-        {
-            "spraak": "default",
-            "verdi": "Mål for opplæringa er at eleven skal kunne"
-        }
-    ],
-    "etter-fag": [
-        {
-            "kode": "MAT1Z34",
-            "uri": "http://psi.udir.no/kl06/MAT1Z34",
-            "url-data": "http://data.udir.no/kl06/MAT1Z34",
-            "grep-type": "http://psi.udir.no/ontologi/kl06/opplaeringsfag",
-            "status": "http://data.udir.no/kl06/status_publisert",
-            "tittel": "Matematikk 10. årstrinn",
-            "gyldighet": {
-                "gyldig-fra": "2020-08-01T00:00:00",
-                "gyldig-til": null
+    "url-data": "http://data.udir.no/kl06/v201906/kompetansemaalsett-lk20/KMS9",
+    "tittel": {
+        "tekst": [
+            {
+                "spraak": "default",
+                "verdi": "Kompetansemål og vurdering 10. trinn"
             }
+        ],
+        "forskrift": true
+    },
+    "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaalsett_lk20",
+    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+    "sist-endret": "2018-12-12T13:16:05.228885",
+    "kortform": [],
+    "rekkefoelge": 9,
+    "forklaring": [
+        {
+            "spraak": "default",
+            "verdi": "Forklaring på kompetansemålsett"
         }
     ],
+    "kompetansemaal-overskrift": {
+        "tekst": [
+            {
+                "spraak": "default",
+                "verdi": "Kompetansemål etter 10. trinn"
+            }
+        ],
+        "forskrift": true
+    },
+    "kompetansemaal-ingress": {
+        "tekst": [
+            {
+                "spraak": "default",
+                "verdi": "Mål for opplæringa er at eleven skal kunne"
+            }
+        ],
+        "forskrift:": true
+    },
     "kompetansemaal": [
         {
-            "rekkefoelge": 1,
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "uuid:e53cac6e-2e27-11e9-b210-d663bd873d93",
             "kode": "K98",
             "uri": "http://psi.udir.no/kl06/K98",
-            "url-data": "http://data.udir.no/kl06/K98",
+            "url-data": "http://data.udir.no/kl06/v201906/kompetansemaal-lk20/K98",
             "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "utforske og bruke kvadratsetningar og konjugatsetninga numerisk, algebraisk og geometrisk"
         },
         {
-            "rekkefoelge": 2,
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "uuid:ed9df7fa-2e27-11e9-b210-d663bd873d93",
             "kode": "K99",
             "uri": "http://psi.udir.no/kl06/K99",
-            "url-data": "http://data.udir.no/kl06/K99",
+            "url-data": "http://data.udir.no/kl06/v201906/kompetansemaal-lk20/K99",
             "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "bruke dei algebraiske lovmessigheitene, finne samanhengar og deretter formalisere ved bruk av formålstenlege representasjonar"
         }
     ],
     "underveisvurdering": {
-        "overskrift": [
+        "overskrift": {
+            "tekst": [
+                {
+                    "spraak": "default",
+                    "verdi": "Underveisvurdering"
+                }
+            ],
+            "forskrift": true
+        },
+        "beskrivelse": {
+            "tekst": [
+                {
+                    "spraak": "default",
+                    "verdi": "Eleven viser kompetanse i matematikk gjennom å utforske og kommunisere matematiske omgrep og generalisere matematiske samanhengar. Eleven kan bruke den matematiske kompetansen sin i problemløysing og modellering og kan reflektere over sine eigne arbeidsprosessar. Eleven kan presentere løysingar og argumentere for at dei er gyldige."
+                }
+            ],
+            "forskrift": true
+        },
+        "forklaring": [
             {
                 "spraak": "default",
-                "verdi": "Underveisvurdering"
-            }
-        ],
-        "beskrivelse": [
-            {
-                "spraak": "default",
-                "verdi": "Eleven viser kompetanse i matematikk gjennom å utforske og kommunisere matematiske omgrep og generalisere matematiske samanhengar. Eleven kan bruke den matematiske kompetansen sin i problemløysing og modellering og kan reflektere over sine eigne arbeidsprosessar. Eleven kan presentere løysingar og argumentere for at dei er gyldige."
-            }
-        ]
-    },
-    "sluttvurdering": {
-        "overskrift": [
-            {
-                "spraak": "default",
-                "verdi": "Sluttvurdering"
-            }
-        ],
-        "beskrivelse": [
-            {
-                "spraak": "default",
-                "verdi": "Omtalen av sluttvurderinga er ikkje klar til denne innspelsrunden."
+                "verdi": "Forklaring på undervegsvurdering"
             }
         ]
     },
+    "standpunktvurdering": {
+        "overskrift": {
+            "tekst": [
+                {
+                    "spraak": "default",
+                    "verdi": "Standpunktvurdering"
+                }
+            ],
+            "forskrift": true
+        },
+        "beskrivelse": {
+            "tekst": [
+                {
+                    "spraak": "default",
+                    "verdi": "Omtalen av standpunktvurderinga er ikkje klar til denne innspelsrunden."
+                }
+            ],
+            "forskrift": true
+        },
+        "forklaring": [
+            {
+                "spraak": "default",
+                "verdi": "Forklaring på standpunktvurdering"
+            }
+        ]
+    },
+    "etter-fag": [
+        {
+            "gyldighet": {
+                "gyldig-fra": "2020-08-01T00:00:00",
+                "gyldig-til": null
+            },
+            "id": "uuid:1b7ffca0-787f-4387-9dfa-42ac0469a88f",
+            "kode": "MAT1Z34",
+            "uri": "http://psi.udir.no/kl06/MAT1Z34",
+            "url-data": "http://data.udir.no/kl06/v201906/opplaeringsfag/MAT1Z34",
+            "grep-type": "http://psi.udir.no/ontologi/kl06/opplaeringsfag",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+            "tittel": "Matematikk 10. årstrinn"
+        }
+    ],
     "etter-aarstrinn": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.udir.no/laereplan/aarstrinn/aarstrinn10",
             "kode": "aarstrinn10",
             "uri": "http://psi.udir.no/kl06/aarstrinn10",
-            "url-data": "http://data.udir.no/kl06/aarstrinn10",
+            "url-data": "http://data.udir.no/kl06/v201906/aarstrinn/aarstrinn10",
             "grep-type": "http://psi.udir.no/ontologi/kl06/aarstrinn",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Tiende årstrinn"
         }
     ],
     "benyttes-paa-aarstrinn": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.udir.no/laereplan/aarstrinn/aarstrinn10",
             "kode": "aarstrinn10",
             "uri": "http://psi.udir.no/kl06/aarstrinn10",
-            "url-data": "http://data.udir.no/kl06/aarstrinn10",
+            "url-data": "http://data.udir.no/kl06/v201906/aarstrinn/aarstrinn10",
             "grep-type": "http://psi.udir.no/ontologi/kl06/aarstrinn",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Tiende årstrinn"
         }
     ],
     "tilhoerer-laereplan": {
+        "gyldighet": {
+            "gyldig-fra": null,
+            "gyldig-til": null
+        },
+        "id": "uuid:3c03c709-4934-4012-9353-c14bfa8ff651",
         "kode": "MAT1-05",
         "uri": "http://psi.udir.no/kl06/MAT1-05",
-        "url-data": "http://data.udir.no/kl06/MAT1-05",
+        "url-data": "http://data.udir.no/kl06/v201906/laereplaner-lk20/MAT1-05",
         "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
+        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
         "tittel": "Matematikk fellesfag"
     }
 }

--- a/eksempler/laereplaner/FYS1-02.json
+++ b/eksempler/laereplaner/FYS1-02.json
@@ -2,7 +2,7 @@
     "id": "uuid:af2d1482-232e-11e9-ab14-d663bd873d93",
     "kode": "FYS1-02",
     "uri": "http://psi.udir.no/kl06/FYS1-02",
-    "url-data": "http://data.udir.no/kl06/FYS1-02",
+    "url-data": "http://data.udir.no/kl06/v201906/laereplaner-lk20/FYS1-02",
     "tittel": {
         "tekst": [
             {
@@ -13,7 +13,7 @@
         "forskrift": true
     },
     "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
-    "status": "http://data.udir.no/kl06/status_publisert",
+    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
     "sist-endret": "2018-12-12T13:16:05.228885",
     "om-faget-kapittel": {
         "overskrift": {
@@ -63,70 +63,30 @@
             },
             "kjerneelementer": [
                 {
-                    "overskrift": {
-                        "tekst": [
-                            {
-                                "spraak": "Default",
-                                "verdi": "Klassisk fysikk"
-                            }
-                        ],
-                        "forskrift": true
+                    "gyldighet": {
+                        "gyldig-fra": null,
+                        "gyldig-til": null
                     },
-                    "beskrivelse": {
-                        "tekst": [
-                            {
-                                "spraak": "Default",
-                                "verdi": "Kjerneelementet handler om de eldste og mest brukte fysikklovene, og hvordan de kommer til uttrykk innen mekanikk, elektrisitetslære og termofysikk. Et sentralt prinsipp er bevaring av energi i ulike prosesser. Videre dreier det seg om grunnleggende begreper som er nødvendige for å arbeide med bølgefenomener."
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "forklaring": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Forklaring på klassisk fysikk"
-                        }
-                    ],
-                    "referanse": {
-                        "kode": "KE90",
-                        "uri": "http://psi.udir.no/kl06/KE90",
-                        "url-data": "http://data.udir.no/kl06/KE90",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
-                        "tittel": "Klassisk fysikk"
-                    }
+                    "id": "uuid:f07d240e-2df6-11e9-b210-d663bd873d93",
+                    "kode": "KE90",
+                    "uri": "http://psi.udir.no/kl06/KE90",
+                    "url-data": "http://data.udir.no/kl06/v201906/kjerneelementer-lk20/KE90",
+                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
+                    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                    "tittel": "Klassisk fysikk"
                 },
                 {
-                    "overskrift": {
-                        "tekst": [
-                            {
-                                "spraak": "Default",
-                                "verdi": "Moderne fysikk"
-                            }
-                        ],
-                        "forskrift": true
+                    "gyldighet": {
+                        "gyldig-fra": null,
+                        "gyldig-til": null
                     },
-                    "beskrivelse": {
-                        "tekst": [
-                            {
-                                "spraak": "Default",
-                                "verdi": "Kjerneelementet handler om byggesteinene i naturen og hvordan de settes sammen, fra mikrokosmos til makrokosmos. I tillegg dreier det seg om informasjon som kan leses ut av stråling i ulike sammenhenger, og hvordan den kan brukes til å lage modeller som kan beskrive verden."
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "forklaring": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Forklaring på moderne fysikk"
-                        }
-                    ],
-                    "referanse": {
-                        "kode": "KE91",
-                        "uri": "http://psi.udir.no/kl06/KE91",
-                        "url-data": "http://data.udir.no/kl06/KE91",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
-                        "tittel": "Moderne fysikk"
-                    }
+                    "id": "uuid:2152af72-2df7-11e9-89f0-d663bd873d93",
+                    "kode": "KE91",
+                    "uri": "http://psi.udir.no/kl06/KE91",
+                    "url-data": "http://data.udir.no/kl06/v201906/kjerneelementer-lk20/KE91",
+                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
+                    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                    "tittel": "Moderne fysikk"
                 }
             ]
         },
@@ -193,10 +153,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:c28b7650-0366-11e9-8eb2-f2801f1b9fd1",
                         "kode": "TT1",
                         "uri": "http://psi.udir.no/kl06/TT1",
-                        "url-data": "http://data.udir.no/kl06/TT1",
+                        "url-data": "http://data.udir.no/kl06/v201906/tverrfaglige-temaer-lk20/TT1",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/tverrfaglig_tema_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Folkehelse og livsmestring"
                     }
                 },
@@ -226,10 +192,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:7336758a-2df7-11e9-b210-d663bd873d93",
                         "kode": "TT2",
                         "uri": "http://psi.udir.no/kl06/TT2",
-                        "url-data": "http://data.udir.no/kl06/TT2",
+                        "url-data": "http://data.udir.no/kl06/v201906/tverrfaglige-temaer-lk20/TT2",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/tverrfaglig_tema_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Demokrati og medborgarskap"
                     }
                 },
@@ -259,10 +231,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:8aef2abe-2df7-11e9-b210-d663bd873d93",
                         "kode": "TT3",
                         "uri": "http://psi.udir.no/kl06/TT3",
-                        "url-data": "http://data.udir.no/kl06/TT3",
+                        "url-data": "http://data.udir.no/kl06/v201906/tverrfaglige-temaer-lk20/TT3",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/tverrfaglig_tema_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Bærekraftig utvikling"
                     }
                 }
@@ -305,10 +283,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:ceba24a2-0501-11e9-8eb2-f2801f1b9fd1",
                         "kode": "GF1",
                         "uri": "http://psi.udir.no/kl06/GF1",
-                        "url-data": "http://data.udir.no/kl06/GF1",
+                        "url-data": "http://data.udir.no/kl06/v201906/grunnleggende-ferdigheter-lk20/GF1",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Digitale ferdigheter"
                     }
                 },
@@ -338,10 +322,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:c9448b2e-2df7-11e9-b210-d663bd873d93",
                         "kode": "GF2",
                         "uri": "http://psi.udir.no/kl06/GF2",
-                        "url-data": "http://data.udir.no/kl06/GF2",
+                        "url-data": "http://data.udir.no/kl06/v201906/grunnleggende-ferdigheter-lk20/GF2",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Muntlige ferdigheter"
                     }
                 },
@@ -371,10 +361,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:e11ab304-2df7-11e9-b210-d663bd873d93",
                         "kode": "GF3",
                         "uri": "http://psi.udir.no/kl06/GF3",
-                        "url-data": "http://data.udir.no/kl06/GF3",
+                        "url-data": "http://data.udir.no/kl06/v201906/grunnleggende-ferdigheter-lk20/GF3",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Å kunne lese"
                     }
                 },
@@ -404,10 +400,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:f97eda06-2df7-11e9-b210-d663bd873d93",
                         "kode": "GF4",
                         "uri": "http://psi.udir.no/kl06/GF4",
-                        "url-data": "http://data.udir.no/kl06/GF4",
+                        "url-data": "http://data.udir.no/kl06/v201906/grunnleggende-ferdigheter-lk20/GF4",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Å kunne regne"
                     }
                 },
@@ -437,10 +439,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:0e5aa270-2df8-11e9-b210-d663bd873d93",
                         "kode": "GF5",
                         "uri": "http://psi.udir.no/kl06/GF5",
-                        "url-data": "http://data.udir.no/kl06/GF5",
+                        "url-data": "http://data.udir.no/kl06/v201906/grunnleggende-ferdigheter-lk20/GF5",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Å kunne skrive"
                     }
                 }
@@ -459,649 +467,30 @@
         },
         "kompetansemaalsett": [
             {
-                "rekkefoelge": 1,
+                "gyldighet": {
+                    "gyldig-fra": null,
+                    "gyldig-til": null
+                },
                 "id": "uuid:06adc5c8-232d-11e9-ab14-d663bd873d93",
                 "kode": "KMS30",
                 "uri": "http://psi.udir.no/kl06/KMS30",
-                "url-data": "http://data.udir.no/kl06/KMS30",
-                "tittel": {
-                    "tekst": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Kompetansemål og vurdering"
-                        }
-                    ],
-                    "forskrift": true
-                },
+                "url-data": "http://data.udir.no/kl06/v201906/kompetansemaalsett-lk20/KMS30",
                 "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaalsett_lk20",
-                "kortform": null,
-                "forklaring": [
-                    {
-                        "spraak": "default",
-                        "verdi": "Forklaring på kompetansemålsett"
-                    }
-                ],
-                "kompetansemaal-overskrift": [
-                    {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Fysikk 1"
-                            }
-                        ],
-                        "forskrift": true
-                    }
-                ],
-                "kompetansemaal-ingress": [
-                    {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Mål for opplæringen er at eleven skal kunne"
-                            }
-                        ],
-                        "forskrift": true
-                    }
-                ],
-                "etter-fag": [
-                    {
-                        "kode": "FYS1Z01",
-                        "uri": "http://psi.udir.no/kl06/FYS1Z01",
-                        "url-data": "http://data.udir.no/kl06/FYS1Z01",
-                        "status": "http://data.udir.no/kl06/status_publisert",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/opplaeringsfag",
-                        "gyldighet": {
-                            "gyldig-fra": "2020-08-01T00:00:00",
-                            "gyldig-til": null
-                        },
-                        "tittel": "Fysikk 1"
-                    }
-                ],
-                "kompetansemaal": [
-                    {
-                        "rekkefoelge": 1,
-                        "kode": "K270",
-                        "uri": "http://psi.udir.no/kl06/K270",
-                        "url-data": "http://data.udir.no/kl06/K270",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-                        "tittel": {
-                            "tekst": [
-                                {
-                                    "spraak": "default",
-                                    "verdi": "gjøre rede for energibegrepet og begrepene arbeid og effekt og foreta beregninger og drøfte situasjoner der mekanisk energi er bevart"
-                                }
-                            ],
-                            "forskrift": true
-                        },
-                        "forklaring": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Forklaring på kompetansemål"
-                            }
-                        ],
-                        "tilknyttede-tverrfaglige-tema": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på folkehelse og livsmestring"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "TT1",
-                                    "uri": "http://psi.udir.no/kl06/TT1",
-                                    "url-data": "http://data.udir.no/kl06/TT1",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/tverrfaglig_tema_lk20",
-                                    "tittel": "Folkehelse og livsmestring"
-                                }
-                            }
-                        ],
-                        "tilknyttede-kjerneelementer": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på klassisk fysikk"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "KE90",
-                                    "uri": "http://psi.udir.no/kl06/KE90",
-                                    "url-data": "http://data.udir.no/kl06/KE90",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
-                                    "tittel": "Klassisk fysikk"
-                                }
-                            }
-                        ],
-                        "tilknyttede-grunnleggende-ferdigheter": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på muntlige ferdigheter"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "GF2",
-                                    "uri": "http://psi.udir.no/kl06/GF2",
-                                    "url-data": "http://data.udir.no/kl06/GF2",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
-                                    "tittel": "Muntlige ferdigheter"
-                                }
-                            }
-                        ],
-                        "tilknyttede-verb": [
-                            {
-                                "referanse": {
-                                    "kode": "VERB6",
-                                    "uri": "http://psi.udir.no/kl06/VERB6",
-                                    "url-data": "http://data.udir.no/kl06/VERB6",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/verb_lk20",
-                                    "tittel": "Drøfte"
-                                }
-                            },
-                            {
-                                "referanse": {
-                                    "kode": "VERB9",
-                                    "uri": "http://psi.udir.no/kl06/VERB9",
-                                    "url-data": "http://data.udir.no/kl06/VERB9",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/verb_lk20",
-                                    "tittel": "Gjøre rede for"
-                                }
-                            }
-                        ],
-                        "bygger-paa": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på bygger på kompetansemål"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "K269",
-                                    "uri": "http://psi.udir.no/kl06/K269",
-                                    "url-data": "http://data.udir.no/kl06/K269",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-                                    "tittel": "identifisere kontaktkrefter og gravitasjonskrefter som virker på legemer, tegne kraftvektorer og bruke Newtons tre lover"
-                                }
-                            }
-                        ],
-                        "samme-som": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på samme som kompetansemål"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "K273",
-                                    "uri": "http://psi.udir.no/kl06/K273",
-                                    "url-data": "http://data.udir.no/kl06/K273",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-                                    "tittel": "gjengi og drøfte kvalitativt termofysikkens første og andre lov"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "rekkefoelge": 2,
-                        "kode": "K271",
-                        "uri": "http://psi.udir.no/kl06/K271",
-                        "url-data": "http://data.udir.no/kl06/K271",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-                        "tittel": {
-                            "tekst": [
-                                {
-                                    "spraak": "default",
-                                    "verdi": "gjøre rede for situasjoner der friksjon og luftmotstand gjør at den mekaniske energien ikke er bevart, og gjøre beregninger i situasjoner med konstant friksjon"
-                                }
-                            ],
-                            "forskrift": true
-                        },
-                        "forklaring": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Forklaring på kompetansemål"
-                            }
-                        ],
-                        "tilknyttede-tverrfaglige-tema": [],
-                        "tilknyttede-kjerneelementer": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på moderne fysikk"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "KE91",
-                                    "uri": "http://psi.udir.no/kl06/KE91",
-                                    "url-data": "http://data.udir.no/kl06/KE91",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
-                                    "tittel": "Moderne fysikk"
-                                }
-                            }
-                        ],
-                        "tilknyttede-grunnleggende-ferdigheter": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på muntlige ferdigheter"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "GF2",
-                                    "uri": "http://psi.udir.no/kl06/GF2",
-                                    "url-data": "http://data.udir.no/kl06/GF2",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
-                                    "tittel": "Muntlige ferdigheter"
-                                }
-                            }
-                        ],
-                        "tilknyttede-verb": [
-                            {
-                                "referanse": {
-                                    "kode": "VERB9",
-                                    "uri": "http://psi.udir.no/kl06/VERB9",
-                                    "url-data": "http://data.udir.no/kl06/VERB9",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/verb_lk20",
-                                    "tittel": "Gjøre rede for"
-                                }
-                            }
-                        ],
-                        "bygger-paa": [],
-                        "samme-som": []
-                    }
-                ],
-                "underveisvurdering": {
-                    "overskrift": {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Underveisvurdering"
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "beskrivelse": {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Omtalen av underveisvurdering er ikke klar til denne innspillsrunden."
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "forklaring": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Forklaring på underveisvurdering"
-                        }
-                    ]
-                },
-                "sluttvurdering": {
-                    "overskrift": {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Sluttvurdering"
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "beskrivelse": {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Elevene skal ha standpunktkarakter. Elevene kan trekkes ut til muntlig-praktisk eksamen. Eksamen blir utarbeidet og sensurert lokalt."
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "forklaring": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Forklaring på sluttvurdering"
-                        }
-                    ]
-                },
-                "etter-aarstrinn": [
-                    {
-                        "kode": "vg2",
-                        "uri": "http://psi.udir.no/kl06/vg2",
-                        "url-data": "http://data.udir.no/kl06/vg2",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/aarstrinn",
-                        "tittel": "Videregående trinn 2"
-                    },
-                    {
-                        "kode": "vg3",
-                        "uri": "http://psi.udir.no/kl06/vg3",
-                        "url-data": "http://data.udir.no/kl06/vg3",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/aarstrinn",
-                        "tittel": "Videregående trinn 3"
-                    }
-                ],
-                "benyttes-paa-aarstrinn": [
-                    {
-                        "kode": "vg2",
-                        "uri": "http://psi.udir.no/kl06/vg2",
-                        "url-data": "http://data.udir.no/kl06/vg2",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/aarstrinn",
-                        "tittel": "Videregående trinn 2"
-                    },
-                    {
-                        "kode": "vg3",
-                        "uri": "http://psi.udir.no/kl06/vg3",
-                        "url-data": "http://data.udir.no/kl06/vg3",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/aarstrinn",
-                        "tittel": "Videregående trinn 3"
-                    }
-                ]
+                "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                "tittel": "Kompetansemål og vurdering Fysikk 1"
             },
             {
-                "rekkefoelge": 2,
+                "gyldighet": {
+                    "gyldig-fra": null,
+                    "gyldig-til": null
+                },
                 "id": "uuid:15062e26-2332-11e9-ab14-d663bd873d93",
                 "kode": "KMS31",
                 "uri": "http://psi.udir.no/kl06/KMS31",
-                "url-data": "http://data.udir.no/kl06/KMS31",
-                "tittel": {
-                    "tekst": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Kompetansemål og vurdering"
-                        }
-                    ],
-                    "forskrift": true
-                },
+                "url-data": "http://data.udir.no/kl06/v201906/kompetansemaalsett-lk20/KMS31",
                 "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaalsett_lk20",
-                "kortform": null,
-                "forklaring": [
-                    {
-                        "spraak": "default",
-                        "verdi": "Forklaring på kompetansemålsett"
-                    }
-                ],
-                "kompetansemaal-overskrift": [
-                    {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Fysikk 2"
-                            }
-                        ],
-                        "forskrift": true
-                    }
-                ],
-                "kompetansemaal-ingress": [
-                    {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Mål for opplæringen er at eleven skal kunne"
-                            }
-                        ],
-                        "forskrift": true
-                    }
-                ],
-                "etter-fag": [
-                    {
-                        "kode": "FYS1Z02",
-                        "uri": "http://psi.udir.no/kl06/FYS1Z02",
-                        "url-data": "http://data.udir.no/kl06/FYS1Z02",
-                        "status": "http://data.udir.no/kl06/status_publisert",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/opplaeringsfag",
-                        "gyldighet": {
-                            "gyldig-fra": "2020-08-01T00:00:00",
-                            "gyldig-til": null
-                        },
-                        "tittel": "Fysikk 2"
-                    }
-                ],
-                "kompetansemaal": [
-                    {
-                        "rekkefoelge": 1,
-                        "kode": "K277",
-                        "uri": "http://psi.udir.no/kl06/K277",
-                        "url-data": "http://data.udir.no/kl06/K277",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-                        "tittel": {
-                            "tekst": [
-                                {
-                                    "spraak": "default",
-                                    "verdi": "beskrive homogene og inhomogene elektriske felt og bruke Coulombs lov"
-                                }
-                            ],
-                            "forskrift": true
-                        },
-                        "forklaring": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Forklaring på kompetansemål"
-                            }
-                        ],
-                        "tilknyttede-tverrfaglige-tema": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på folkehelse og livsmestring"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "TT1",
-                                    "uri": "http://psi.udir.no/kl06/TT1",
-                                    "url-data": "http://data.udir.no/kl06/TT1",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/tverrfaglig_tema_lk20",
-                                    "tittel": "Folkehelse og livsmestring"
-                                }
-                            }
-                        ],
-                        "tilknyttede-kjerneelementer": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på klassisk fysikk"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "KE90",
-                                    "uri": "http://psi.udir.no/kl06/KE90",
-                                    "url-data": "http://data.udir.no/kl06/KE90",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
-                                    "tittel": "Klassisk fysikk"
-                                }
-                            }
-                        ],
-                        "tilknyttede-grunnleggende-ferdigheter": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på muntlige ferdigheter"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "GF2",
-                                    "uri": "http://psi.udir.no/kl06/GF2",
-                                    "url-data": "http://data.udir.no/kl06/GF2",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
-                                    "tittel": "Muntlige ferdigheter"
-                                }
-                            }
-                        ],
-                        "tilknyttede-verb": [
-                            {
-                                "referanse": {
-                                    "kode": "VERB3",
-                                    "uri": "http://psi.udir.no/kl06/VERB3",
-                                    "url-data": "http://data.udir.no/kl06/VERB3",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/verb_lk20",
-                                    "tittel": "Beskrive"
-                                }
-                            }
-                        ],
-                        "bygger-paa": [],
-                        "samme-som": []
-                    },
-                    {
-                        "rekkefoelge": 2,
-                        "kode": "K278",
-                        "uri": "http://psi.udir.no/kl06/K278",
-                        "url-data": "http://data.udir.no/kl06/K278",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-                        "tittel": {
-                            "tekst": [
-                                {
-                                    "spraak": "default",
-                                    "verdi": "eskrive magnetiske felt rundt permanentmagneter og elektriske strømmer, og beregne magnetisk flukstetthet rundt en rett leder og kraft på en leder i magnetisk felt"
-                                }
-                            ],
-                            "forskrift": true
-                        },
-                        "forklaring": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Forklaring på kompetansemål"
-                            }
-                        ],
-                        "tilknyttede-tverrfaglige-tema": [],
-                        "tilknyttede-kjerneelementer": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på moderne fysikk"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "KE91",
-                                    "uri": "http://psi.udir.no/kl06/KE91",
-                                    "url-data": "http://data.udir.no/kl06/KE91",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
-                                    "tittel": "Moderne fysikk"
-                                }
-                            }
-                        ],
-                        "tilknyttede-grunnleggende-ferdigheter": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på muntlige ferdigheter"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "GF2",
-                                    "uri": "http://psi.udir.no/kl06/GF2",
-                                    "url-data": "http://data.udir.no/kl06/GF2",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
-                                    "tittel": "Muntlige ferdigheter"
-                                }
-                            }
-                        ],
-                        "tilknyttede-verb": [
-                            {
-                                "referanse": {
-                                    "kode": "VERB3",
-                                    "uri": "http://psi.udir.no/kl06/VERB3",
-                                    "url-data": "http://data.udir.no/kl06/VERB3",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/verb_lk20",
-                                    "tittel": "Beskrive"
-                                }
-                            }
-                        ],
-                        "bygger-paa": [],
-                        "samme-som": []
-                    }
-                ],
-                "underveisvurdering": {
-                    "overskrift": {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Underveisvurdering"
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "beskrivelse": {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Omtalen av underveisvurdering er ikke klar til denne innspillsrunden."
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "forklaring": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Forklaring på underveisvurdering"
-                        }
-                    ]
-                },
-                "sluttvurdering": {
-                    "overskrift": {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Sluttvurdering"
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "beskrivelse": {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Elevene skal ha standpunktkarakter. Elevene kan trekkes ut til muntlig-praktisk eksamen. Eksamen blir utarbeidet og sensurert lokalt."
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "forklaring": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Forklaring på sluttvurdering"
-                        }
-                    ]
-                },
-                "etter-aarstrinn": [
-                    {
-                        "kode": "vg2",
-                        "uri": "http://psi.udir.no/kl06/vg2",
-                        "url-data": "http://data.udir.no/kl06/vg2",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/aarstrinn",
-                        "tittel": "Videregående trinn 2"
-                    },
-                    {
-                        "kode": "vg3",
-                        "uri": "http://psi.udir.no/kl06/vg3",
-                        "url-data": "http://data.udir.no/kl06/vg3",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/aarstrinn",
-                        "tittel": "Videregående trinn 3"
-                    }
-                ],
-                "benyttes-paa-aarstrinn": [
-                    {
-                        "kode": "vg2",
-                        "uri": "http://psi.udir.no/kl06/vg2",
-                        "url-data": "http://data.udir.no/kl06/vg2",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/aarstrinn",
-                        "tittel": "Videregående trinn 2"
-                    },
-                    {
-                        "kode": "vg3",
-                        "uri": "http://psi.udir.no/kl06/vg3",
-                        "url-data": "http://data.udir.no/kl06/vg3",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/aarstrinn",
-                        "tittel": "Videregående trinn 3"
-                    }
-                ]
+                "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                "tittel": "Kompetansemål og vurdering Fysikk 2"
             }
         ]
     },
@@ -1111,13 +500,20 @@
         "fastsettelsestekst": [
             {
                 "spraak": "default",
-                "verdi": "Fastsatt som forskrift av Utdanningsdirektoratet 3. april 2006 etter delegasjon i brev 26. september 2005 fra Utdannings- og forskningsdepartementet med hjemmel i lov av 17. juli 1998 nr. 61 om grunnskolen og den vidaregåande opplæringa (opplæringslova) § 3-4 første ledd."            }
+                "verdi": "Fastsatt som forskrift av Utdanningsdirektoratet 3. april 2006 etter delegasjon i brev 26. september 2005 fra Utdannings- og forskningsdepartementet med hjemmel i lov av 17. juli 1998 nr. 61 om grunnskolen og den vidaregåande opplæringa (opplæringslova) § 3-4 første ledd."
+            }
         ],
         "fastsatt-spraak": {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.oasis-open.org/iso/639/#nob",
             "kode": "nob",
             "uri": "http://psi.udir.no/kl06/nob",
-            "url-data": "http://data.udir.no/kl06/nob",
+            "url-data": "http://data.udir.no/kl06/v201906/spraak/nob",
             "grep-type": "http://psi.udir.no/ontologi/kl06/spraak",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Bokmål"
         },
         "fastsatt-dato-overskrift": [
@@ -1128,34 +524,58 @@
         ]
     },
     "fagtype": {
+        "gyldighet": {
+            "gyldig-fra": null,
+            "gyldig-til": null
+        },
+        "id": "http://psi.udir.no/ontologi/valgfritt_programfag",
         "kode": "fagtype_valgfritt_programfag",
         "uri": "http://psi.udir.no/kl06/fagtype_valgfritt_programfag",
-        "url-data": "http://data.udir.no/kl06/fagtype_valgfritt_programfag",
+        "url-data": "http://data.udir.no/kl06/v201906/fagtype/fagtype_valgfritt_programfag",
         "grep-type": "http://psi.udir.no/ontologi/kl06/fagtype",
+        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
         "tittel": "Valgfritt programfag"
     },
     "tilgjengelige-spraak": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.oasis-open.org/iso/639/#eng",
             "kode": "eng",
             "uri": "http://psi.udir.no/kl06/eng",
-            "url-data": "http://data.udir.no/kl06/eng",
+            "url-data": "http://data.udir.no/kl06/v201906/spraak/eng",
             "grep-type": "http://psi.udir.no/ontologi/kl06/spraak",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Engelsk"
         },
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.oasis-open.org/iso/639/#nob",
             "kode": "nob",
             "uri": "http://psi.udir.no/kl06/nob",
-            "url-data": "http://data.udir.no/kl06/nob",
+            "url-data": "http://data.udir.no/kl06/v201906/spraak/nob",
             "grep-type": "http://psi.udir.no/ontologi/kl06/spraak",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Bokmål"
         }
     ],
     "opplaeringsnivaa": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.udir.no/ontologi/opplaeringsnivaa_videregaaende",
             "kode": "opplaeringsnivaa_videregaaende",
             "uri": "http://psi.udir.no/kl06/opplaeringsnivaa_videregaaende",
-            "url-data": "http://data.udir.no/kl06/opplaeringsnivaa_videregaaende",
+            "url-data": "http://data.udir.no/kl06/v201906/opplaeringsnivaa/opplaeringsnivaa_videregaaende",
             "grep-type": "http://psi.udir.no/ontologi/kl06/opplaeringsnivaa",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Videregående opplæring"
         }
     ],
@@ -1181,21 +601,31 @@
     },
     "erstatter": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "uuid:bd010713-4427-4da6-be3b-d31b90c7197e",
             "kode": "FYS1-01",
             "uri": "http://psi.udir.no/kl06/FYS1-01",
-            "url-data": "http://data.udir.no/kl06/FYS1-01",
-            "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
-            "status": "http://data.udir.no/kl06/status_utgaatt",
+            "url-data": "http://data.udir.no/kl06/v201906/laereplaner/FYS1-01",
+            "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan",
+            "status": "http://data.udir.no/kl06/v201906/status/status_utgaatt",
             "tittel": "Læreplan i fysikk - programfag i utdanningsprogram for studiespesialisering"
         }
     ],
     "erstattes-av": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "uuid:d911dee2-2df9-11e9-b210-d663bd873d93",
             "kode": "FYS1-03",
             "uri": "http://psi.udir.no/kl06/FYS1-03",
-            "url-data": "http://data.udir.no/kl06/FYS1-03",
+            "url-data": "http://data.udir.no/kl06/v201906/laereplaner-lk20/FYS1-03",
             "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
-            "status": "http://data.udir.no/kl06/status_publisert",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Læreplan i fysikk - programfag i utdanningsprogram for studiespesialisering"
         }
     ],

--- a/eksempler/laereplaner/MAT1-05.json
+++ b/eksempler/laereplaner/MAT1-05.json
@@ -2,7 +2,7 @@
     "id": "uuid:3c03c709-4934-4012-9353-c14bfa8ff651",
     "kode": "MAT1-05",
     "uri": "http://psi.udir.no/kl06/MAT1-05",
-    "url-data": "http://data.udir.no/kl06/MAT1-05",
+    "url-data": "http://data.udir.no/kl06/v201906/laereplaner-lk20/MAT1-05",
     "tittel": {
         "tekst": [
             {
@@ -13,7 +13,7 @@
         "forskrift": true
     },
     "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
-    "status": "http://data.udir.no/kl06/status_publisert",
+    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
     "sist-endret": "2018-12-12T13:16:05.228885",
     "om-faget-kapittel": {
         "overskrift": {
@@ -63,70 +63,82 @@
             },
             "kjerneelementer": [
                 {
-                    "overskrift": {
-                        "tekst": [
-                            {
-                                "spraak": "Default",
-                                "verdi": "Utforsking og problemløysing"
-                            }
-                        ],
-                        "forskrift": true
+                    "gyldighet": {
+                        "gyldig-fra": null,
+                        "gyldig-til": null
                     },
-                    "beskrivelse": {
-                        "tekst": [
-                            {
-                                "spraak": "Default",
-                                "verdi": "Dette kjerneelementet er det viktigaste for faget og for høvet til djupnelæring. Dei andre kjerneelementa må sjåast i samanheng med dette. Utforsking handlar om at elevane leiter etter mønster og finn samanhengar. Det må leggjast meir vekt på ulike strategiar og framgangsmåtar enn på sjølve løysingane. Problemløysing handlar om at elevane utviklar løysingsmetodar på eit problem dei ikkje kjenner frå før. Algoritmisk tenking er viktig i prosessen med å utvikle strategiar og framgangsmåtar og inneber å kunne bryte ned eit problem i delproblem som kan løysast systematisk. Viktig innhald vil vere å kunne stille matematiske spørsmål og formulere matematiske problemstillingar, identifisere problem, vere uthaldande, utvikle og kunne velje effektive problemløysingsstrategiar og utforske og løyse problem ved hjelp av programmering. Elevane må få høve til å vere nysgjerrige, også på fagstoff som dei ikkje elles møter av matematikk på trinnet sitt."
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "forklaring": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Forklaring på utforsking og problemløysing"
-                        }
-                    ],
-                    "referanse": {
-                        "kode": "KE1",
-                        "uri": "http://psi.udir.no/kl06/KE1",
-                        "url-data": "http://data.udir.no/kl06/KE1",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
-                        "tittel": "Utforsking og problemløysing"
-                    }
+                    "id": "uuid:d570dcc2-0381-11e9-8eb2-f2801f1b9fd1",
+                    "kode": "KE1",
+                    "uri": "http://psi.udir.no/kl06/KE1",
+                    "url-data": "http://data.udir.no/kl06/v201906/kjerneelementer-lk20/KE1",
+                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
+                    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                    "tittel": "Utforsking og problemløysing"
                 },
                 {
-                    "overskrift": {
-                        "tekst": [
-                            {
-                                "spraak": "Default",
-                                "verdi": "Modellering og bruk"
-                            }
-                        ],
-                        "forskrift": true
+                    "gyldighet": {
+                        "gyldig-fra": null,
+                        "gyldig-til": null
                     },
-                    "beskrivelse": {
-                        "tekst": [
-                            {
-                                "spraak": "Default",
-                                "verdi": "Elevane skal ha innsikt i korleis matematikk blir brukt i dagleglivet, samfunnslivet og innanfor vitskap og teknologi. Det inneber å ta ei problemstilling frå verkelegheita, formulere henne om til ein matematisk modell og tolke modellen i lys av den opphavlege situasjonen. Elevane bør få innsikt i korleis modellar kan brukast i nye situasjonar. Viktig kompetanse vil vere å kunne omsetje til eit matematisk språk, bruke matematiske modellar og tolke løysingar, vurdere gyldigheitsområdet og avgrensingane til ein modell, utvikle kritisk tenking og vurdere når det er formålstenleg å bruke programmering til å utforske matematiske modellar. Funksjonar, måling og statistikk vil vere viktige innhaldselement."
-                            }
-                        ],
-                        "forskrift": true
+                    "id": "uuid:30f11c54-2e04-11e9-b210-d663bd873d93",
+                    "kode": "KE2",
+                    "uri": "http://psi.udir.no/kl06/KE2",
+                    "url-data": "http://data.udir.no/kl06/v201906/kjerneelementer-lk20/KE2",
+                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
+                    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                    "tittel": "Modellering og bruk"
+                },
+                {
+                    "gyldighet": {
+                        "gyldig-fra": null,
+                        "gyldig-til": null
                     },
-                    "forklaring": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Forklaring på modellering og bruk"
-                        }
-                    ],
-                    "referanse": {
-                        "kode": "KE2",
-                        "uri": "http://psi.udir.no/kl06/KE2",
-                        "url-data": "http://data.udir.no/kl06/KE2",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
-                        "tittel": "Modellering og bruk"
-                    }
+                    "id": "uuid:ba04eb08-2f65-11e9-b210-d663bd873d93",
+                    "kode": "KE3",
+                    "uri": "http://psi.udir.no/kl06/KE3",
+                    "url-data": "http://data.udir.no/kl06/v201906/kjerneelementer-lk20/KE3",
+                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
+                    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                    "tittel": "Resonnering og argumentasjon"
+                },
+                {
+                    "gyldighet": {
+                        "gyldig-fra": null,
+                        "gyldig-til": null
+                    },
+                    "id": "uuid:c04ec39e-2f65-11e9-b210-d663bd873d93",
+                    "kode": "KE4",
+                    "uri": "http://psi.udir.no/kl06/KE4",
+                    "url-data": "http://data.udir.no/kl06/v201906/kjerneelementer-lk20/KE4",
+                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
+                    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                    "tittel": "Representasjon og kommunikasjon"
+                },
+                {
+                    "gyldighet": {
+                        "gyldig-fra": null,
+                        "gyldig-til": null
+                    },
+                    "id": "uuid:c564ea16-2f65-11e9-b210-d663bd873d93",
+                    "kode": "KE5",
+                    "uri": "http://psi.udir.no/kl06/KE5",
+                    "url-data": "http://data.udir.no/kl06/v201906/kjerneelementer-lk20/KE5",
+                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
+                    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                    "tittel": "Abstraksjon og generalisering"
+                },
+                {
+                    "gyldighet": {
+                        "gyldig-fra": null,
+                        "gyldig-til": null
+                    },
+                    "id": "uuid:caa71864-2f65-11e9-b210-d663bd873d93",
+                    "kode": "KE6",
+                    "uri": "http://psi.udir.no/kl06/KE6",
+                    "url-data": "http://data.udir.no/kl06/v201906/kjerneelementer-lk20/KE6",
+                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
+                    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                    "tittel": "Matematiske kunnskapsområde"
                 }
             ]
         },
@@ -181,7 +193,7 @@
                         "tekst": [
                             {
                                 "spraak": "default",
-                                "verdi": "Folkehelse og livsmestring er tatt med i dette faget pga..."
+                                "verdi": "Det å forstå korleis prosessar i samfunnet fungerer, er ein føresetnad for å delta i samfunnslivet. Teknologi blir ein større og større del av kvardagen vår, og det krev forståing for algoritmisk tenking og den påverknaden vi blir utsette for i dagleglivet. Det å kunne vurdere val knytte til personleg økonomi og kunne reflektere over konsekvensar skal òg vere ein naturleg del av matematikkfaget på alle hovudtrinna. Mange elevar opplever svak meistring i matematikkfaget, noko som seinare kan påverke meistring i livet. Matematikkfaget skal derfor leggje vekt på relevans, kreativitet, medverknad, meistring og motivasjon gjennom heile skuleløpet."
                             }
                         ],
                         "forskrift": true
@@ -193,10 +205,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:c28b7650-0366-11e9-8eb2-f2801f1b9fd1",
                         "kode": "TT1",
                         "uri": "http://psi.udir.no/kl06/TT1",
-                        "url-data": "http://data.udir.no/kl06/TT1",
+                        "url-data": "http://data.udir.no/kl06/v201906/tverrfaglige-temaer-lk20/TT1",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/tverrfaglig_tema_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Folkehelse og livsmestring"
                     }
                 },
@@ -214,7 +232,7 @@
                         "tekst": [
                             {
                                 "spraak": "default",
-                                "verdi": "Demokrati og medborgarskap er tatt med i dette faget pga..."
+                                "verdi": "Matematikk er eit reiskapsfag. For å kunne vere ein aktiv medborgar og delta i og forstå eit demokrati er det viktig at ein kan lese, forstå og bruke tal, målingar og statistikk. Kvar einaste dag gjer vi målingar, berekningar og utrekningar. Bak all digital kommunikasjon ligg det ein kode. Skal ein kunne ta avgjerder, må ein kunne vurdere løysingar og gyldigheit. Matematiske modellar, mønster, omgrep, former og figurar er ein del av omgivnadene våre. Matematisk forståing er derfor viktig for den enkelte, både for å forstå samfunnet vi lever i, og for å meistre kvardagen."
                             }
                         ],
                         "forskrift": true
@@ -226,10 +244,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:8b65bce4-2e04-11e9-b210-d663bd873d93",
                         "kode": "TT2",
                         "uri": "http://psi.udir.no/kl06/TT2",
-                        "url-data": "http://data.udir.no/kl06/TT2",
+                        "url-data": "http://data.udir.no/kl06/v201906/tverrfaglige-temaer-lk20/TT2",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/tverrfaglig_tema_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Demokrati og medborgarskap"
                     }
                 },
@@ -247,7 +271,7 @@
                         "tekst": [
                             {
                                 "spraak": "default",
-                                "verdi": "Bærekraftig utvikling er tatt med i dette faget pga..."
+                                "verdi": "Matematikk er eit viktig fag som bidreg til å gjere elevane i stand til å forstå og argumentere for avgjerder i sin eigen kvardag og i samfunnet elles. Kritisk tenking, samarbeid og argumentasjon gjer elevane til demokratiske medborgarar som kan bidra med berekraftige løysingar på problem og utfordringar både i lokalmiljøet og i samfunnet elles. Reflektert bruk av statistikk og vurdering av talstorleikar er sentralt for å kunne ta gjennomtenkte avgjerder innanfor politikk og samfunnsliv."
                             }
                         ],
                         "forskrift": true
@@ -259,10 +283,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:af290ad2-2e04-11e9-b210-d663bd873d93",
                         "kode": "TT3",
                         "uri": "http://psi.udir.no/kl06/TT3",
-                        "url-data": "http://data.udir.no/kl06/TT3",
+                        "url-data": "http://data.udir.no/kl06/v201906/tverrfaglige-temaer-lk20/TT3",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/tverrfaglig_tema_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Bærekraftig utvikling"
                     }
                 }
@@ -305,10 +335,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:ceba24a2-0501-11e9-8eb2-f2801f1b9fd1",
                         "kode": "GF1",
                         "uri": "http://psi.udir.no/kl06/GF1",
-                        "url-data": "http://data.udir.no/kl06/GF1",
+                        "url-data": "http://data.udir.no/kl06/v201906/grunnleggende-ferdigheter-lk20/GF1",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Digitale ferdigheter"
                     }
                 },
@@ -338,10 +374,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:15e965b4-2e05-11e9-b210-d663bd873d93",
                         "kode": "GF2",
                         "uri": "http://psi.udir.no/kl06/GF2",
-                        "url-data": "http://data.udir.no/kl06/GF2",
+                        "url-data": "http://data.udir.no/kl06/v201906/grunnleggende-ferdigheter-lk20/GF2",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Muntlige ferdigheter"
                     }
                 },
@@ -371,10 +413,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:319cc206-2e05-11e9-b210-d663bd873d93",
                         "kode": "GF3",
                         "uri": "http://psi.udir.no/kl06/GF3",
-                        "url-data": "http://data.udir.no/kl06/GF3",
+                        "url-data": "http://data.udir.no/kl06/v201906/grunnleggende-ferdigheter-lk20/GF3",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Å kunne lese"
                     }
                 },
@@ -404,10 +452,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:4d12ed62-2e05-11e9-b210-d663bd873d93",
                         "kode": "GF4",
                         "uri": "http://psi.udir.no/kl06/GF4",
-                        "url-data": "http://data.udir.no/kl06/GF4",
+                        "url-data": "http://data.udir.no/kl06/v201906/grunnleggende_ferdigheter-lk20/GF4",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Å kunne regne"
                     }
                 },
@@ -437,10 +491,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:6882d7a6-2e05-11e9-b210-d663bd873d93",
                         "kode": "GF5",
                         "uri": "http://psi.udir.no/kl06/GF5",
-                        "url-data": "http://data.udir.no/kl06/GF5",
+                        "url-data": "http://data.udir.no/kl06/v201906/grunnleggende_ferdigheter-lk20/GF5",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Å kunne skrive"
                     }
                 }
@@ -459,586 +519,30 @@
         },
         "kompetansemaalsett": [
             {
-                "rekkefoelge": 1,
+                "gyldighet": {
+                    "gyldig-fra": null,
+                    "gyldig-til": null
+                },
                 "id": "uuid:129ca8c7-e839-4551-a2e2-9998f48f1f81",
                 "kode": "KMS1",
                 "uri": "http://psi.udir.no/kl06/KMS1",
-                "url-data": "http://data.udir.no/kl06/KMS1",
-                "tittel": {
-                    "tekst": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Kompetansemål og vurdering 2. trinn"
-                        }
-                    ],
-                    "forskrift": true
-                },
+                "url-data": "http://data.udir.no/kl06/v201906/kompetansemaalsett-lk20/KMS1",
                 "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaalsett_lk20",
-                "kortform": null,
-                "forklaring": [
-                    {
-                        "spraak": "default",
-                        "verdi": "Forklaring på kompetansemålsett"
-                    }
-                ],
-                "kompetansemaal-overskrift": [
-                    {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Kompetansemål etter 2. trinn"
-                            }
-                        ],
-                        "forskrift": true
-                    }
-                ],
-                "kompetansemaal-ingress": [
-                    {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Mål for opplæringa er at eleven skal kunne"
-                            }
-                        ],
-                        "forskrift": true
-                    }
-                ],
-                "etter-fag": [
-                    {
-                        "kode": "MAT1Z25",
-                        "uri": "http://psi.udir.no/kl06/MAT1Z25",
-                        "url-data": "http://data.udir.no/kl06/MAT1Z25",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/opplaeringsfag",
-                        "status": "http://data.udir.no/kl06/status_publisert",
-                        "gyldighet": {
-                            "gyldig-fra": "2020-08-01T00:00:00",
-                            "gyldig-til": null
-                        },
-                        "tittel": "Matematikk 1. årstrinn"
-                    },
-                    {
-                        "kode": "MAT1Z26",
-                        "uri": "http://psi.udir.no/kl06/MAT1Z26",
-                        "url-data": "http://data.udir.no/kl06/MAT1Z26",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/opplaeringsfag",
-                        "status": "http://data.udir.no/kl06/status_publisert",
-                        "gyldighet": {
-                            "gyldig-fra": "2020-08-01T00:00:00",
-                            "gyldig-til": null
-                        },
-                        "tittel": "Matematikk 2. årstrinn"
-                    }
-                ],
-                "kompetansemaal": [
-                    {
-                        "rekkefoelge": 1,
-                        "kode": "K1",
-                        "uri": "http://psi.udir.no/kl06/K1",
-                        "url-data": "http://data.udir.no/kl06/K1",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-                        "tittel": {
-                            "tekst": [
-                                {
-                                    "spraak": "default",
-                                    "verdi": "samanlikne ulike storleikar og mengder og uttrykkje dette gjennom eige språk og matematisk språk"
-                                }
-                            ],
-                            "forskrift": true
-                        },
-                        "forklaring": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Forklaring på kompetansemål"
-                            }
-                        ],
-                        "tilknyttede-tverrfaglige-tema": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på folkehelse og livsmestring"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "TT1",
-                                    "uri": "http://psi.udir.no/kl06/TT1",
-                                    "url-data": "http://data.udir.no/kl06/TT1",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/tverrfaglig_tema_lk20",
-                                    "tittel": "Folkehelse og livsmestring"
-                                }
-                            }
-                        ],
-                        "tilknyttede-kjerneelementer": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på utforsking og problemløysing"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "KE1",
-                                    "uri": "http://psi.udir.no/kl06/KE1",
-                                    "url-data": "http://data.udir.no/kl06/KE1",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
-                                    "tittel": "Utforsking og problemløysing"
-                                }
-                            }
-                        ],
-                        "tilknyttede-grunnleggende-ferdigheter": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på digitale ferdigheter"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "GF1",
-                                    "uri": "http://psi.udir.no/kl06/GF1",
-                                    "url-data": "http://data.udir.no/kl06/GF1",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
-                                    "tittel": "Digitale ferdigheter"
-                                }
-                            }
-                        ],
-                        "tilknyttede-verb": [
-                            {
-                                "referanse": {
-                                    "kode": "VERB14",
-                                    "uri": "http://psi.udir.no/kl06/VERB14",
-                                    "url-data": "http://data.udir.no/kl06/VERB14",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/verb_lk20",
-                                    "tittel": "Sammenligne"
-                                }
-                            }
-                        ],
-                        "bygger-paa": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på bygger på kompetansemål"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "K3",
-                                    "uri": "http://psi.udir.no/kl06/K3",
-                                    "url-data": "http://data.udir.no/kl06/K3",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-                                    "tittel": "utforske og beskrive mengder og eigenskapar ved mengder og representere mengder på forskjellige måtar"
-                                }
-                            }
-                        ],
-                        "samme-som": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på samme som kompetansemål"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "K1",
-                                    "uri": "http://psi.udir.no/kl06/K1",
-                                    "url-data": "http://data.udir.no/kl06/K1",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-                                    "tittel": "ordne og sortere gjenstandar ut frå ulike eigenskapar og diskutere om dette kan gjerast på fleire måtar"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "rekkefoelge": 2,
-                        "kode": "K2",
-                        "uri": "http://psi.udir.no/kl06/K2",
-                        "url-data": "http://data.udir.no/kl06/K2",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-                        "tittel": {
-                            "tekst": [
-                                {
-                                    "spraak": "default",
-                                    "verdi": "leike og eksperimentere med ulike typar teljing i praktiske situasjonar"
-                                }
-                            ],
-                            "forskrift": true
-                        },
-                        "forklaring": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Forklaring på kompetansemål"
-                            }
-                        ],
-                        "tilknyttede-tverrfaglige-tema": [],
-                        "tilknyttede-kjerneelementer": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på modellering og bruk"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "KE2",
-                                    "uri": "http://psi.udir.no/kl06/KE2",
-                                    "url-data": "http://data.udir.no/kl06/KE2",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
-                                    "tittel": "Modellering og bruk"
-                                }
-                            }
-                        ],
-                        "tilknyttede-grunnleggende-ferdigheter": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på muntlige ferdigheter"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "GF2",
-                                    "uri": "http://psi.udir.no/kl06/GF2",
-                                    "url-data": "http://data.udir.no/kl06/GF2",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
-                                    "tittel": "Muntlige ferdigheter"
-                                }
-                            }
-                        ],
-                        "tilknyttede-verb": [],
-                        "bygger-paa": [],
-                        "samme-som": []
-                    }
-                ],
-                "underveisvurdering": {
-                    "overskrift": {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Underveisvurdering"
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "beskrivelse": {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Eleven viser kompetanse i matematikk gjennom å utforske mønster i leik og snakke om samanhengar og eigenskapar. Eleven kan bruke tal og mengder i ulike situasjonar og kan representere tal og mengder på varierte måtar. Eleven kan bruke den matematiske kompetansen sin i problemløysing og daglegliv og kan reflektere over sine eigne framgangsmåtar."
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "forklaring": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Forklaring på underveisvurdering"
-                        }
-                    ]
-                },
-                "sluttvurdering": null,
-                "etter-aarstrinn": [
-                    {
-                        "kode": "aarstrinn2",
-                        "uri": "http://psi.udir.no/kl06/aarstrinn2",
-                        "url-data": "http://data.udir.no/kl06/aarstrinn2",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/aarstrinn",
-                        "tittel": "Andre årstrinn"
-                    }
-                ],
-                "benyttes-paa-aarstrinn": [
-                    {
-                        "kode": "aarstrinn1",
-                        "uri": "http://psi.udir.no/kl06/aarstrinn1",
-                        "url-data": "http://data.udir.no/kl06/aarstrinn1",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/aarstrinn",
-                        "tittel": "Første årstrinn"
-                    },
-                    {
-                        "kode": "aarstrinn2",
-                        "uri": "http://psi.udir.no/kl06/aarstrinn2",
-                        "url-data": "http://data.udir.no/kl06/aarstrinn2",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/aarstrinn",
-                        "tittel": "Andre årstrinn"
-                    }
-                ]
+                "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                "tittel": "Kompetansemål og vurdering 2. trinn"
             },
             {
-                "rekkefoelge": 2,
+                "gyldighet": {
+                    "gyldig-fra": null,
+                    "gyldig-til": null
+                },
                 "id": "uuid:d0a1d4fd-cb72-4608-8269-39270144364b",
                 "kode": "KMS9",
                 "uri": "http://psi.udir.no/kl06/KM9",
-                "url-data": "http://data.udir.no/kl06/KMS9",
-                "tittel": {
-                    "tekst": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Kompetansemål og vurdering 10. trinn"
-                        }
-                    ],
-                    "forskrift": true
-                },
+                "url-data": "http://data.udir.no/kl06/v201906/kompetansemaalsett-lk20/KMS9",
                 "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaalsett_lk20",
-                "kortform": null,
-                "forklaring": [
-                    {
-                        "spraak": "default",
-                        "verdi": "Forklaring på kompetansemålsett"
-                    }
-                ],
-                "kompetansemaal-overskrift": [
-                    {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Kompetansemål etter 10. trinn"
-                            }
-                        ],
-                        "forskrift": true
-                    }
-                ],
-                "kompetansemaal-ingress": [
-                    {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Mål for opplæringa er at eleven skal kunne"
-                            }
-                        ],
-                        "forskrift": true
-                    }
-                ],
-                "etter-fag": [
-                    {
-                        "kode": "MAT1Z34",
-                        "uri": "http://psi.udir.no/kl06/MAT1Z34",
-                        "url-data": "http://data.udir.no/kl06/MAT1Z34",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/opplaeringsfag",
-                        "status": "http://data.udir.no/kl06/status_publisert",
-                        "gyldighet": {
-                            "gyldig-fra": "2020-08-01T00:00:00",
-                            "gyldig-til": null
-                        },
-                        "tittel": "Matematikk 10. årstrinn"
-                    }
-                ],
-                "kompetansemaal": [
-                    {
-                        "rekkefoelge": 1,
-                        "kode": "K98",
-                        "uri": "http://psi.udir.no/kl06/K98",
-                        "url-data": "http://data.udir.no/kl06/K98",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-                        "tittel": {
-                            "tekst": [
-                                {
-                                    "spraak": "default",
-                                    "verdi": "utforske og bruke kvadratsetningar og konjugatsetninga numerisk, algebraisk og geometrisk"
-                                }
-                            ],
-                            "forskrift": true
-                        },
-                        "forklaring": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Forklaring på kompetansemål"
-                            }
-                        ],
-                        "tilknyttede-tverrfaglige-tema": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på folkehelse og livsmestring"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "TT1",
-                                    "uri": "http://psi.udir.no/kl06/TT1",
-                                    "url-data": "http://data.udir.no/kl06/TT1",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/tverrfaglig_tema_lk20",
-                                    "tittel": "Folkehelse og livsmestring"
-                                }
-                            }
-                        ],
-                        "tilknyttede-kjerneelementer": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på utforsking og problemløysing"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "KE1",
-                                    "uri": "http://psi.udir.no/kl06/KE1",
-                                    "url-data": "http://data.udir.no/kl06/KE1",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
-                                    "tittel": "Utforsking og problemløysing"
-                                }
-                            }
-                        ],
-                        "tilknyttede-grunnleggende-ferdigheter": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på digitale ferdigheter"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "GF1",
-                                    "uri": "http://psi.udir.no/kl06/GF1",
-                                    "url-data": "http://data.udir.no/kl06/GF1",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
-                                    "tittel": "Digitale ferdigheter"
-                                }
-                            }
-                        ],
-                        "tilknyttede-verb": [
-                            {
-                                "referanse": {
-                                    "kode": "VERB16",
-                                    "uri": "http://psi.udir.no/kl06/VERB16",
-                                    "url-data": "http://data.udir.no/kl06/VERB16",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/verb_lk20",
-                                    "tittel": "Utforske"
-                                }
-                            }
-                        ],
-                        "bygger-paa": [],
-                        "samme-som": []
-                    },
-                    {
-                        "rekkefoelge": 2,
-                        "kode": "K99",
-                        "uri": "http://psi.udir.no/kl06/K99",
-                        "url-data": "http://data.udir.no/kl06/K99",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-                        "tittel": {
-                            "tekst": [
-                                {
-                                    "spraak": "default",
-                                    "verdi": "bruke dei algebraiske lovmessigheitene, finne samanhengar og deretter formalisere ved bruk av formålstenlege representasjonar"
-                                }
-                            ],
-                            "forskrift": true
-                        },
-                        "forklaring": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Forklaring på kompetansemål"
-                            }
-                        ],
-                        "tilknyttede-tverrfaglige-tema": [],
-                        "tilknyttede-kjerneelementer": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på modellering og bruk"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "KE2",
-                                    "uri": "http://psi.udir.no/kl06/KE2",
-                                    "url-data": "http://data.udir.no/kl06/KE2",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
-                                    "tittel": "Modellering og bruk"
-                                }
-                            }
-                        ],
-                        "tilknyttede-grunnleggende-ferdigheter": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på muntlige ferdigheter"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "GF2",
-                                    "uri": "http://test-psi.udir.no/kl06/GF2",
-                                    "url-data": "http://test-data.udir.no/kl06/GF2",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
-                                    "tittel": "Muntlige ferdigheter"
-                                }
-                            }
-                        ],
-                        "tilknyttede-verb": [],
-                        "bygger-paa": [],
-                        "samme-som": []
-                    }
-                ],
-                "underveisvurdering": {
-                    "overskrift": {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Underveisvurdering"
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "beskrivelse": {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Eleven viser kompetanse i matematikk gjennom å utforske og kommunisere matematiske omgrep og generalisere matematiske samanhengar. Eleven kan bruke den matematiske kompetansen sin i problemløysing og modellering og kan reflektere over sine eigne arbeidsprosessar. Eleven kan presentere løysingar og argumentere for at dei er gyldige."
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "forklaring": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Forklaring på underveisvurdering"
-                        }
-                    ]
-                },
-                "sluttvurdering": {
-                    "overskrift": {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Sluttvurdering"
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "beskrivelse": {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Omtalen av sluttvurderinga er ikkje klar til denne innspelsrunden."
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "forklaring": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Forklaring på sluttvurdering"
-                        }
-                    ]
-                },
-                "etter-aarstrinn": [
-                    {
-                        "kode": "aarstrinn10",
-                        "uri": "http://psi.udir.no/kl06/aarstrinn10",
-                        "url-data": "http://data.udir.no/kl06/aarstrinn10",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/aarstrinn",
-                        "tittel": "Tiende årstrinn"
-                    }
-                ],
-                "benyttes-paa-aarstrinn": [
-                    {
-                        "kode": "aarstrinn10",
-                        "uri": "http://psi.udir.no/kl06/aarstrinn10",
-                        "url-data": "http://data.udir.no/kl06/aarstrinn10",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/aarstrinn",
-                        "tittel": "Tiende årstrinn"
-                    }
-                ]
+                "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                "tittel": "Kompetansemål og vurdering 10. trinn"
             }
         ]
     },
@@ -1052,10 +556,16 @@
             }
         ],
         "fastsatt-spraak": {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.oasis-open.org/iso/639/#nno",
             "kode": "nno",
             "uri": "http://psi.udir.no/kl06/nno",
-            "url-data": "http://data.udir.no/kl06/nno",
+            "url-data": "http://data.udir.no/kl06/v201906/spraak/nno",
             "grep-type": "http://psi.udir.no/ontologi/kl06/spraak",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Nynorsk"
         },
         "fastsatt-dato-overskrift": [
@@ -1066,69 +576,123 @@
         ]
     },
     "fagtype": {
+        "gyldighet": {
+            "gyldig-fra": null,
+            "gyldig-til": null
+        },
+        "id": "http://psi.udir.no/ontologi/fellesfag",
         "kode": "fagtype_fellesfag",
         "uri": "http://psi.udir.no/kl06/fagtype_fellesfag",
-        "url-data": "http://data.udir.no/kl06/fagtype_fellesfag",
+        "url-data": "http://data.udir.no/kl06/v201906/fagtype/fagtype_fellesfag",
         "grep-type": "http://psi.udir.no/ontologi/kl06/fagtype",
+        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
         "tittel": "Fellesfag"
     },
     "tilgjengelige-spraak": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.oasis-open.org/iso/639/#nob",
             "kode": "nob",
             "uri": "http://psi.udir.no/kl06/nob",
-            "url-data": "http://data.udir.no/kl06/nob",
+            "url-data": "http://data.udir.no/kl06/v201906/spraak/nob",
             "grep-type": "http://psi.udir.no/ontologi/kl06/spraak",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Bokmål"
         },
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.oasis-open.org/iso/639/#eng",
             "kode": "eng",
             "uri": "http://psi.udir.no/kl06/eng",
-            "url-data": "http://data.udir.no/kl06/eng",
+            "url-data": "http://data.udir.no/kl06/v201906/spraak/eng",
             "grep-type": "http://psi.udir.no/ontologi/kl06/spraak",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Engelsk"
         },
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.oasis-open.org/iso/639/#smj",
             "kode": "smj",
             "uri": "http://psi.udir.no/kl06/smj",
-            "url-data": "http://data.udir.no/kl06/smj",
+            "url-data": "http://data.udir.no/kl06/v201906/spraak/smj",
             "grep-type": "http://psi.udir.no/ontologi/kl06/spraak",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Lulesamisk"
         },
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.oasis-open.org/iso/639/#sme",
             "kode": "sme",
             "uri": "http://psi.udir.no/kl06/sme",
-            "url-data": "http://data.udir.no/kl06/sme",
+            "url-data": "http://data.udir.no/kl06/v201906/spraak/sme",
             "grep-type": "http://psi.udir.no/ontologi/kl06/spraak",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Nordsamisk"
         },
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.oasis-open.org/iso/639/#nno",
             "kode": "nno",
             "uri": "http://psi.udir.no/kl06/nno",
-            "url-data": "http://data.udir.no/kl06/nno",
+            "url-data": "http://data.udir.no/kl06/v201906/spraak/nno",
             "grep-type": "http://psi.udir.no/ontologi/kl06/spraak",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Nynorsk"
         },
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.oasis-open.org/iso/639/#sma",
             "kode": "sma",
             "uri": "http://psi.udir.no/kl06/sma",
-            "url-data": "http://data.udir.no/kl06/sma",
+            "url-data": "http://data.udir.no/kl06/v201906/spraak/sma",
             "grep-type": "http://psi.udir.no/ontologi/kl06/spraak",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Sørsamisk"
         }
     ],
     "opplaeringsnivaa": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.udir.no/ontologi/opplaeringsnivaa_grunnskole",
             "kode": "opplaeringsnivaa_grunnskole",
             "uri": "http://psi.udir.no/kl06/opplaeringsnivaa_grunnskole",
-            "url-data": "http://data.udir.no/kl06/opplaeringsnivaa_grunnskole",
+            "url-data": "http://data.udir.no/kl06/v201906/opplaeringsnivaa/opplaeringsnivaa_grunnskole",
             "grep-type": "http://psi.udir.no/ontologi/kl06/opplaeringsnivaa",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Grunnskole"
         },
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.udir.no/ontologi/opplaeringsnivaa_videregaaende",
             "kode": "opplaeringsnivaa_videregaaende",
             "uri": "http://psi.udir.no/kl06/opplaeringsnivaa_videregaaende",
-            "url-data": "http://data.udir.no/kl06/opplaeringsnivaa_videregaaende",
+            "url-data": "http://data.udir.no/kl06/v201906/opplaeringsnivaa/opplaeringsnivaa_videregaaende",
             "grep-type": "http://psi.udir.no/ontologi/kl06/opplaeringsnivaa",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Videregående opplæring"
         }
     ],
@@ -1154,21 +718,31 @@
     },
     "erstatter": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "uuid:efc05c69-f7df-4134-8ab1-6fbcb3a642f3",
             "kode": "MAT1-04",
             "uri": "http://psi.udir.no/kl06/MAT1-04",
-            "url-data": "http://data.udir.no/kl06/MAT1-04",
-            "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
-            "status": "http://data.udir.no/kl06/status_utgaatt",
+            "url-data": "http://data.udir.no/kl06/v201906/laereplaner/MAT1-04",
+            "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan",
+            "status": "http://data.udir.no/kl06/v201906/status/status_utgaatt",
             "tittel": "Læreplan i matematikk fellesfag"
         }
     ],
     "erstattes-av": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "uuid:67c1a4b2-2e07-11e9-b210-d663bd873d93",
             "kode": "MAT1-06",
             "uri": "http://psi.udir.no/kl06/MAT1-06",
-            "url-data": "http://data.udir.no/kl06/MAT1-06",
+            "url-data": "http://data.udir.no/kl06/v201906/laereplaner-lk20/MAT1-06",
             "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
-            "status": "http://data.udir.no/kl06/status_publisert",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Læreplan i matematikk fellesfag"
         }
     ],

--- a/eksempler/laereplaner/TMF3-02.json
+++ b/eksempler/laereplaner/TMF3-02.json
@@ -2,7 +2,7 @@
     "id": "uuid:1cdd3528-2327-11e9-ab14-d663bd873d93",
     "kode": "TMF3-02",
     "uri": "http://psi.udir.no/kl06/TMF3-02",
-    "url-data": "http://data.udir.no/kl06/TMF3-02",
+    "url-data": "http://data.udir.no/kl06/v201906/laereplaner-lk20/TMF3-02",
     "tittel": {
         "tekst": [
             {
@@ -13,7 +13,7 @@
         "forskrift": true
     },
     "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
-    "status": "http://data.udir.no/kl06/status_publisert",
+    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
     "sist-endret": "2018-12-12T13:16:05.228885",
     "om-faget-kapittel": {
         "overskrift": {
@@ -63,70 +63,30 @@
             },
             "kjerneelementer": [
                 {
-                    "overskrift": {
-                        "tekst": [
-                            {
-                                "spraak": "Default",
-                                "verdi": "Produksjon"
-                            }
-                        ],
-                        "forskrift": true
+                    "gyldighet": {
+                        "gyldig-fra": null,
+                        "gyldig-til": null
                     },
-                    "beskrivelse": {
-                        "tekst": [
-                            {
-                                "spraak": "Default",
-                                "verdi": "Kjerneelementet handlar om oppsetjing av nye bygg med bruk av ulike typar materiale. Det omfattar også rehabilitering og vedlikehald av eksisterande bygningar. Byggjeskikkar og sikring av estetiske og kulturelle verdiar står sentralt. Kjerneelementet omfattar bruk av verktøy og maskiner, bruk av preaksepterte løysingar og kvalitetssystem, teikningar og beskrivingar og gjeldande regelverk. Planlegging, gjennomføring, dokumentasjon og vurdering av arbeid høyrer med. Kjerneelementet dekkjer også kjeldesortering, avfallshandtering og helse, miljø og tryggleik."
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "forklaring": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Forklaring på produksjon"
-                        }
-                    ],
-                    "referanse": {
-                        "kode": "KE70",
-                        "uri": "http://psi.udir.no/kl06/KE70",
-                        "url-data": "http://data.udir.no/kl06/KE70",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
-                        "tittel": "Produksjon"
-                    }
+                    "id": "uuid:19a552ae-2e09-11e9-b210-d663bd873d93",
+                    "kode": "KE70",
+                    "uri": "http://psi.udir.no/kl06/KE70",
+                    "url-data": "http://data.udir.no/kl06/v201906/kjerneelementer-lk20/KE70",
+                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
+                    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                    "tittel": "Produksjon"
                 },
                 {
-                    "overskrift": {
-                        "tekst": [
-                            {
-                                "spraak": "Default",
-                                "verdi": "Bransjelære"
-                            }
-                        ],
-                        "forskrift": true
+                    "gyldighet": {
+                        "gyldig-fra": null,
+                        "gyldig-til": null
                     },
-                    "beskrivelse": {
-                        "tekst": [
-                            {
-                                "spraak": "Default",
-                                "verdi": "Kjerneelementet handlar om ulike typar materialar og bruksområda deira. Bruk av beskrivingar, teikningar og dokumentasjon inngår. Prinsipp for oppgradering av eldre bygningar og bygningsfysikk høyrer med. Dessutan inngår faghistorie, kva plass faget har i samfunnet, og etiske retningslinjer."
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "forklaring": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Forklaring på bransjelære"
-                        }
-                    ],
-                    "referanse": {
-                        "kode": "KE71",
-                        "uri": "http://psi.udir.no/kl06/KE71",
-                        "url-data": "http://data.udir.no/kl06/KE71",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
-                        "tittel": "Bransjelære"
-                    }
+                    "id": "uuid:24edf468-2e09-11e9-b210-d663bd873d93",
+                    "kode": "KE71",
+                    "uri": "http://psi.udir.no/kl06/KE71",
+                    "url-data": "http://data.udir.no/kl06/v201906/kjerneelementer-lk20/KE71",
+                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
+                    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                    "tittel": "Bransjelære"
                 }
             ]
         },
@@ -193,10 +153,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:c28b7650-0366-11e9-8eb2-f2801f1b9fd1",
                         "kode": "TT1",
                         "uri": "http://psi.udir.no/kl06/TT1",
-                        "url-data": "http://data.udir.no/kl06/TT1",
+                        "url-data": "http://data.udir.no/kl06/v201906/tverrfaglige-temaer-lk20/TT1",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/tverrfaglig_tema_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Folkehelse og livsmestring"
                     }
                 },
@@ -226,10 +192,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:7336758a-2df7-11e9-b210-d663bd873d93",
                         "kode": "TT2",
                         "uri": "http://psi.udir.no/kl06/TT2",
-                        "url-data": "http://data.udir.no/kl06/TT2",
+                        "url-data": "http://data.udir.no/kl06/v201906/tverrfaglige-temaer-lk20/TT2",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/tverrfaglig_tema_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Demokrati og medborgarskap"
                     }
                 },
@@ -259,10 +231,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:8aef2abe-2df7-11e9-b210-d663bd873d93",
                         "kode": "TT3",
                         "uri": "http://psi.udir.no/kl06/TT3",
-                        "url-data": "http://data.udir.no/kl06/TT3",
+                        "url-data": "http://data.udir.no/kl06/v201906/tverrfaglige-temaer-lk20/TT3",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/tverrfaglig_tema_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Bærekraftig utvikling"
                     }
                 }
@@ -305,10 +283,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:ceba24a2-0501-11e9-8eb2-f2801f1b9fd1",
                         "kode": "GF1",
                         "uri": "http://psi.udir.no/kl06/GF1",
-                        "url-data": "http://data.udir.no/kl06/GF1",
+                        "url-data": "http://data.udir.no/kl06/v201906/grunnleggende-ferdigheter-lk20/GF1",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Digitale ferdigheter"
                     }
                 },
@@ -338,10 +322,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:c9448b2e-2df7-11e9-b210-d663bd873d93",
                         "kode": "GF2",
                         "uri": "http://psi.udir.no/kl06/GF2",
-                        "url-data": "http://data.udir.no/kl06/GF2",
+                        "url-data": "http://data.udir.no/kl06/v201906/grunnleggende-ferdigheter-lk20/GF2",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Muntlige ferdigheter"
                     }
                 },
@@ -371,10 +361,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:e11ab304-2df7-11e9-b210-d663bd873d93",
                         "kode": "GF3",
                         "uri": "http://psi.udir.no/kl06/GF3",
-                        "url-data": "http://data.udir.no/kl06/GF3",
+                        "url-data": "http://data.udir.no/kl06/v201906/grunnleggende-ferdigheter-lk20/GF3",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Å kunne lese"
                     }
                 },
@@ -404,10 +400,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:f97eda06-2df7-11e9-b210-d663bd873d93",
                         "kode": "GF4",
                         "uri": "http://psi.udir.no/kl06/GF4",
-                        "url-data": "http://data.udir.no/kl06/GF4",
+                        "url-data": "http://data.udir.no/kl06/v201906/grunnleggende-ferdigheter-lk20/GF4",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Å kunne regne"
                     }
                 },
@@ -437,10 +439,16 @@
                         }
                     ],
                     "referanse": {
+                        "gyldighet": {
+                            "gyldig-fra": null,
+                            "gyldig-til": null
+                        },
+                        "id": "uuid:0e5aa270-2df8-11e9-b210-d663bd873d93",
                         "kode": "GF5",
                         "uri": "http://psi.udir.no/kl06/GF5",
-                        "url-data": "http://data.udir.no/kl06/GF5",
+                        "url-data": "http://data.udir.no/kl06/v201906/grunnleggende-ferdigheter-lk20/GF5",
                         "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
+                        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
                         "tittel": "Å kunne skrive"
                     }
                 }
@@ -459,332 +467,17 @@
         },
         "kompetansemaalsett": [
             {
-                "rekkefoelge": 1,
-                "id": "uuid:06adc5c8-232d-11e9-ab14-d663bd873d93",
-                "kode": "KMS30",
-                "uri": "http://psi.udir.no/kl06/KMS30",
-                "url-data": "http://data.udir.no/kl06/KMS30",
-                "tittel": {
-                    "tekst": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Kompetansemål og vurdering"
-                        }
-                    ],
-                    "forskrift": true
+                "gyldighet": {
+                    "gyldig-fra": null,
+                    "gyldig-til": null
                 },
+                "id": "uuid:79ec3fc0-2e08-11e9-b210-d663bd873d93",
+                "kode": "KMS60",
+                "uri": "http://psi.udir.no/kl06/KMS60",
+                "url-data": "http://data.udir.no/kl06/v201906/kompetansemaalsett-lk20/KMS60",
                 "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaalsett_lk20",
-                "kortform": null,
-                "forklaring": [
-                    {
-                        "spraak": "default",
-                        "verdi": "Forklaring på kompetansemålsett"
-                    }
-                ],
-                "kompetansemaal-overskrift": [
-                    {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Kompetansemål etter Vg3"
-                            }
-                        ],
-                        "forskrift": true
-                    }
-                ],
-                "kompetansemaal-ingress": [
-                    {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Mål for opplæringa er at lærlingen skal kunne"
-                            }
-                        ],
-                        "forskrift": true
-                    }
-                ],
-                "etter-fag": [
-                    {
-                        "kode": "TMF3Z01",
-                        "uri": "http://psi.udir.no/kl06/TMF3Z01",
-                        "url-data": "http://data.udir.no/kl06/TMF3Z01",
-                        "status": "http://data.udir.no/kl06/status_publisert",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/opplaeringsfag",
-                        "gyldighet": {
-                            "gyldig-fra": "2020-08-01T00:00:00",
-                            "gyldig-til": null
-                        },
-                        "tittel": "Tømrerfaget"
-                    }
-                ],
-                "kompetansemaal": [
-                    {
-                        "rekkefoelge": 1,
-                        "kode": "K170",
-                        "uri": "http://psi.udir.no/kl06/K170",
-                        "url-data": "http://data.udir.no/kl06/K170",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-                        "tittel": {
-                            "tekst": [
-                                {
-                                    "spraak": "default",
-                                    "verdi": "planleggje, utføre, dokumentere og vurdere eige arbeid"
-                                }
-                            ],
-                            "forskrift": true
-                        },
-                        "forklaring": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Forklaring på kompetansemål"
-                            }
-                        ],
-                        "tilknyttede-tverrfaglige-tema": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på folkehelse og livsmestring"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "TT1",
-                                    "uri": "http://psi.udir.no/kl06/TT1",
-                                    "url-data": "http://data.udir.no/kl06/TT1",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/tverrfaglig_tema_lk20",
-                                    "tittel": "Folkehelse og livsmestring"
-                                }
-                            }
-                        ],
-                        "tilknyttede-kjerneelementer": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på produksjon"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "KE70",
-                                    "uri": "http://psi.udir.no/kl06/KE70",
-                                    "url-data": "http://data.udir.no/kl06/KE70",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
-                                    "tittel": "Produksjon"
-                                }
-                            }
-                        ],
-                        "tilknyttede-grunnleggende-ferdigheter": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på muntlige ferdigheter"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "GF2",
-                                    "uri": "http://psi.udir.no/kl06/GF2",
-                                    "url-data": "http://data.udir.no/kl06/GF2",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
-                                    "tittel": "Muntlige ferdigheter"
-                                }
-                            }
-                        ],
-                        "tilknyttede-verb": [
-                            {
-                                "referanse": {
-                                    "kode": "VERB5",
-                                    "uri": "http://psi.udir.no/kl06/VERB5",
-                                    "url-data": "http://data.udir.no/kl06/VERB5",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/verb_lk20",
-                                    "tittel": "Dokumentere"
-                                }
-                            },
-                            {
-                                "referanse": {
-                                    "kode": "VERB10",
-                                    "uri": "http://psi.udir.no/kl06/VERB10",
-                                    "url-data": "http://data.udir.no/kl06/VERB10",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/verb_lk20",
-                                    "tittel": "Planlegge"
-                                }
-                            },
-                            {
-                                "referanse": {
-                                    "kode": "VERB18",
-                                    "uri": "http://psi.udir.no/kl06/VERB18",
-                                    "url-data": "http://data.udir.no/kl06/VERB18",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/verb_lk20",
-                                    "tittel": "Vurdere"
-                                }
-                            }
-                        ],
-                        "bygger-paa": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på bygger på kompetansemål"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "K175",
-                                    "uri": "http://psi.udir.no/kl06/K175",
-                                    "url-data": "http://data.udir.no/kl06/K175",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-                                    "tittel": "utføre byggje- og monteringsarbeid etter teikningar og beskrivingar"
-                                }
-                            }
-                        ],
-                        "samme-som": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på samme som kompetansemål"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "K180",
-                                    "uri": "http://psi.udir.no/kl06/K180",
-                                    "url-data": "http://data.udir.no/kl06/K180",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-                                    "tittel": "velje, tilverke og bruke materialar til konstruksjonar og innreiingsarbeid"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "rekkefoelge": 2,
-                        "kode": "K171",
-                        "uri": "http://psi.udir.no/kl06/K171",
-                        "url-data": "http://data.udir.no/kl06/K171",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-                        "tittel": {
-                            "tekst": [
-                                {
-                                    "spraak": "default",
-                                    "verdi": "byggje om eksisterande bygningar til nye funksjonsområde i samsvar med gjeldande regelverk"
-                                }
-                            ],
-                            "forskrift": true
-                        },
-                        "forklaring": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Forklaring på kompetansemål"
-                            }
-                        ],
-                        "tilknyttede-tverrfaglige-tema": [],
-                        "tilknyttede-kjerneelementer": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på bransjelære"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "KE71",
-                                    "uri": "http://psi.udir.no/kl06/KE71",
-                                    "url-data": "http://data.udir.no/kl06/KE71",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/kjerneelement_lk20",
-                                    "tittel": "Bransjelære"
-                                }
-                            }
-                        ],
-                        "tilknyttede-grunnleggende-ferdigheter": [
-                            {
-                                "forklaring": [
-                                    {
-                                        "spraak": "default",
-                                        "verdi": "Forklaring på muntlige ferdigheter"
-                                    }
-                                ],
-                                "referanse": {
-                                    "kode": "GF2",
-                                    "uri": "http://psi.udir.no/kl06/GF2",
-                                    "url-data": "http://data.udir.no/kl06/GF2",
-                                    "grep-type": "http://psi.udir.no/ontologi/kl06/grunnleggende_ferdighet_lk20",
-                                    "tittel": "Muntlige ferdigheter"
-                                }
-                            }
-                        ],
-                        "tilknyttede-verb": [],
-                        "bygger-paa": [],
-                        "samme-som": []
-                    }
-                ],
-                "underveisvurdering": {
-                    "overskrift": {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Undervegsvurdering"
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "beskrivelse": {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Omtalen av undervegsvurderinga er ikkje klar til denne innspelsrunden."
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "forklaring": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Forklaring på undervegsvurdering"
-                        }
-                    ]
-                },
-                "sluttvurdering": {
-                    "overskrift": {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Sluttvurdering"
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "beskrivelse": {
-                        "tekst": [
-                            {
-                                "spraak": "default",
-                                "verdi": "Alle skal opp til sveineprøva, som normalt skal gjennomførast innanfor ei tidsramme på fem vyrkedagar. Alle kandidatar som ikkje har følgt normalt opplæringsløp, må ha bestått ein eksamen på Vg3-nivå i lærefaget."
-                            }
-                        ],
-                        "forskrift": true
-                    },
-                    "forklaring": [
-                        {
-                            "spraak": "default",
-                            "verdi": "Forklaring på sluttvurdering"
-                        }
-                    ]
-                },
-                "etter-aarstrinn": [
-                    {
-                        "kode": "vg3",
-                        "uri": "http://psi.udir.no/kl06/vg3",
-                        "url-data": "http://data.udir.no/kl06/vg3",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/aarstrinn",
-                        "tittel": "Videregående trinn 3"
-                    }
-                ],
-                "benyttes-paa-aarstrinn": [
-                    {
-                        "kode": "vg3",
-                        "uri": "http://psi.udir.no/kl06/vg3",
-                        "url-data": "http://data.udir.no/kl06/vg3",
-                        "grep-type": "http://psi.udir.no/ontologi/kl06/aarstrinn",
-                        "tittel": "Videregående trinn 3"
-                    }
-                ]
+                "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+                "tittel": "Kompetansemål og vurdering etter Vg3"
             }
         ]
     },
@@ -798,10 +491,16 @@
             }
         ],
         "fastsatt-spraak": {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.oasis-open.org/iso/639/#nno",
             "kode": "nno",
             "uri": "http://psi.udir.no/kl06/nno",
-            "url-data": "http://data.udir.no/kl06/nno",
+            "url-data": "http://data.udir.no/kl06/v201906/spraak/nno",
             "grep-type": "http://psi.udir.no/ontologi/kl06/spraak",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Nynorsk"
         },
         "fastsatt-dato-overskrift": [
@@ -812,34 +511,58 @@
         ]
     },
     "fagtype": {
+        "gyldighet": {
+            "gyldig-fra": null,
+            "gyldig-til": null
+        },
+        "id": "http://psi.udir.no/ontologi/felles_programfag",
         "kode": "fagtype_felles_programfag",
         "uri": "http://psi.udir.no/kl06/fagtype_felles_programfag",
-        "url-data": "http://data.udir.no/kl06/fagtype_felles_programfag",
+        "url-data": "http://data.udir.no/kl06/v201906/fagtype/fagtype_felles_programfag",
         "grep-type": "http://psi.udir.no/ontologi/kl06/fagtype",
+        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
         "tittel": "Felles programfag"
     },
     "tilgjengelige-spraak": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.oasis-open.org/iso/639/#eng",
             "kode": "eng",
             "uri": "http://psi.udir.no/kl06/eng",
-            "url-data": "http://data.udir.no/kl06/eng",
+            "url-data": "http://data.udir.no/kl06/v201906/spraak/eng",
             "grep-type": "http://psi.udir.no/ontologi/kl06/spraak",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Engelsk"
         },
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.oasis-open.org/iso/639/#nno",
             "kode": "nno",
             "uri": "http://psi.udir.no/kl06/nno",
-            "url-data": "http://data.udir.no/kl06/nno",
+            "url-data": "http://data.udir.no/kl06/v201906/spraak/nno",
             "grep-type": "http://psi.udir.no/ontologi/kl06/spraak",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Nynorsk"
         }
     ],
     "opplaeringsnivaa": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.udir.no/ontologi/opplaeringsnivaa_videregaaende",
             "kode": "opplaeringsnivaa_videregaaende",
             "uri": "http://psi.udir.no/kl06/opplaeringsnivaa_videregaaende",
-            "url-data": "http://data.udir.no/kl06/opplaeringsnivaa_videregaaende",
+            "url-data": "http://data.udir.no/kl06/v201906/opplaeringsnivaa/opplaeringsnivaa_videregaaende",
             "grep-type": "http://psi.udir.no/ontologi/kl06/opplaeringsnivaa",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Videregående opplæring"
         }
     ],
@@ -865,31 +588,47 @@
     },
     "erstatter": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "uuid:26a87839-e5d4-4773-bb48-3c6e210ad788",
             "kode": "TMF3-01",
             "uri": "http://psi.udir.no/kl06/TMF3-01",
-            "url-data": "http://data.udir.no/kl06/TMF3-01",
-            "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
-            "status": "http://data.udir.no/kl06/status_utgaatt",
+            "url-data": "http://data.udir.no/kl06/v201906/laereplaner/TMF3-01",
+            "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan",
+            "status": "http://data.udir.no/kl06/v201906/status/status_utgaatt",
             "tittel": "Læreplan i tømrarfaget Vg3 / opplæring i bedrift"
         }
     ],
     "erstattes-av": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "uuid:8887cc00-2e0a-11e9-b210-d663bd873d93",
             "kode": "TMF3-03",
             "uri": "http://psi.udir.no/kl06/TMF3-03",
-            "url-data": "http://data.udir.no/kl06/TMF3-03",
+            "url-data": "http://data.udir.no/kl06/v201906/laereplaner-lk20/MF3-03",
             "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
-            "status": "http://data.udir.no/kl06/status_publisert",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Læreplan i tømrarfaget Vg3 / opplæring i bedrift"
         }
     ],
     "siste-eksamen": "2025-08-01T00:00:00",
     "merkelapper": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "http://psi.udir.no/ontologi/merkelapp/laerling",
             "kode": "laerling",
             "uri": "http://psi.udir.no/kl06/laerling",
-            "url-data": "http://data.udir.no/kl06/laerling",
+            "url-data": "http://data.udir.no/kl06/v201906/merkelapper/laerling",
             "grep-type": "http://psi.udir.no/ontologi/kl06/merkelapp",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Lærlingplan"
         }
     ],

--- a/eksempler/tverrfaglige-temaer/TT1.json
+++ b/eksempler/tverrfaglige-temaer/TT1.json
@@ -2,7 +2,7 @@
     "id": "uuid:c28b7650-0366-11e9-8eb2-f2801f1b9fd1",
     "kode": "TT1",
     "uri": "http://psi.udir.no/kl06/TT1",
-    "url-data": "http://data.udir.no/kl06/TT1",
+    "url-data": "http://data.udir.no/kl06/v201906/tverrfaglige-temaer-lk20/TT1",
     "tittel": [
         {
             "spraak": "default",
@@ -10,26 +10,36 @@
         }
     ],
     "grep-type": "http://psi.udir.no/ontologi/kl06/tverrfaglig_tema_lk20",
-    "status": "http://data.udir.no/kl06/status_publisert",
+    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
     "sist-endret": "2018-12-19T13:16:05.228885",
     "lenke-til-beskrivelse": "https://www.udir.no/laring-og-trivsel/lareplanverket/overordnet-del/prinsipper-for-laring-utvikling-og-danning/tverrfaglige-temaer/folkehelse-og-livsmestring/",
     "laereplan-referanser": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "uuid:3c03c709-4934-4012-9353-c14bfa8ff651",
             "kode": "MAT1-05",
             "uri": "http://psi.udir.no/kl06/MAT1-05",
-            "url-data": "http://data.udir.no/kl06/MAT1-05",
+            "url-data": "http://data.udir.no/kl06/v201906/laereplaner-lk20/MAT1-05",
             "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
-            "status": "http://data.udir.no/kl06/status_publisert",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Matematikk fellesfag"
         }
     ],
     "kompetansemaal-referanser": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "uuid:cec30cd4-1fe6-11e9-8e78-d663bd873d93",
             "kode": "K1",
             "uri": "http://psi.udir.no/kl06/K1",
-            "url-data": "http://data.udir.no/kl06/K1",
+            "url-data": "http://data.udir.no/kl06/v201906/kompetansemaal-lk20/K1",
             "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-            "status": "http://data.udir.no/kl06/status_publisert",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "samanlikne ulike storleikar og mengder og uttrykkje dette gjennom eige språk og matematisk språk"
         }
     ]

--- a/eksempler/verb/VERB14.json
+++ b/eksempler/verb/VERB14.json
@@ -2,7 +2,7 @@
     "id": "uuid:859ec978-fd4d-11e8-8eb2-f2801f1b9fd1",
     "kode": "VERB14",
     "uri": "http://psi.udir.no/kl06/VERB14",
-    "url-data": "http://data.udir.no/kl06/VERB14",
+    "url-data": "http://data.udir.no/kl06/v201906/verb-lk20/VERB14",
     "tittel": [
         {
             "spraak": "default",
@@ -10,7 +10,7 @@
         }
     ],
     "grep-type": "http://psi.udir.no/ontologi/kl06/verb_lk20",
-    "status": "http://data.udir.no/kl06/status_publisert",
+    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
     "sist-endret": "2018-12-11T09:14:20",
     "beskrivelse": [
         {
@@ -21,11 +21,16 @@
     "globalt-verb": true,
     "kompetansemaal-referanser": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "uuid:cec30cd4-1fe6-11e9-8e78-d663bd873d93",
             "kode": "K1",
             "uri": "http://psi.udir.no/kl06/K1",
-            "url-data": "http://data.udir.no/kl06/K1",
+            "url-data": "http://data.udir.no/kl06/v201906/kompetansemaal-lk20/K1",
             "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-            "status": "http://data.udir.no/kl06/status_publisert",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "samanlikne ulike storleikar og mengder og uttrykkje dette gjennom eige språk og matematisk språk"
         }
     ]

--- a/eksempler/verb/VERB20.json
+++ b/eksempler/verb/VERB20.json
@@ -2,7 +2,7 @@
     "id": "uuid:c42a4874-fe34-11e8-8eb2-f2801f1b9fd1",
     "kode": "VERB20",
     "uri": "http://psi.udir.no/kl06/VERB20",
-    "url-data": "http://data.udir.no/kl06/VERB20",
+    "url-data": "http://data.udir.no/kl06/v201906/verb-lk20/VERB20",
     "tittel": [
         {
             "spraak": "default",
@@ -10,7 +10,7 @@
         }
     ],
     "grep-type": "http://psi.udir.no/ontologi/kl06/verb_lk20",
-    "status": "http://data.udir.no/kl06/status_publisert",
+    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
     "sist-endret": "2018-12-11T09:14:20",
     "beskrivelse": [
         {
@@ -20,20 +20,30 @@
     ],
     "globalt-verb": false,
     "tilhoerer-laereplan": {
+        "gyldighet": {
+            "gyldig-fra": null,
+            "gyldig-til": null
+        },
+        "id": "uuid:3c03c709-4934-4012-9353-c14bfa8ff651",
         "kode": "MAT1-05",
         "uri": "http://psi.udir.no/kl06/MAT1-05",
-        "url-data": "http://data.udir.no/kl06/MAT1-05",
+        "url-data": "http://data.udir.no/kl06/v201906/laereplaner-lk20/MAT1-05",
         "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
-        "status": "http://data.udir.no/kl06/status_publisert",
+        "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
         "tittel": "Matematikk fellesfag"
     },
     "kompetansemaal-referanser": [
         {
+            "gyldighet": {
+                "gyldig-fra": null,
+                "gyldig-til": null
+            },
+            "id": "uuid:6026d4f6-2e26-11e9-b210-d663bd873d93",
             "kode": "K4",
             "uri": "http://psi.udir.no/kl06/K4",
-            "url-data": "http://data.udir.no/kl06/K4",
+            "url-data": "http://data.udir.no/kl06/v201906/kompetansemaal-lk20/K4",
             "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-            "status": "http://data.udir.no/kl06/status_publisert",
+            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "tyde og utforske mønster og tal"
         }
     ]


### PR DESCRIPTION
Endringer og korrigeringer i alle eksempelfiler:
* kompetansemålsett, kompetansemål og kjerneelementer er ikke lenger "embedded" i læreplan, erstattet med referanser for å redusere duplisering av data etc.
* ny adressering i data-url
* felles struktur på referanser	