### PR TITLE
Opprettet eksempler på endringer i eksisterende grep-typer

### DIFF
--- a/eksempler/aarstrinn/aarstrinn10.json
+++ b/eksempler/aarstrinn/aarstrinn10.json
@@ -1,0 +1,19 @@
+{
+  "id": "http://psi.udir.no/laereplan/aarstrinn/aarstrinn10",
+  "kode": "aarstrinn10",
+  "uri": "http://psi.udir.no/kl06/aarstrinn10",
+  "url-data": "http://data.udir.no/kl06/v201906/aarstrinn/aarstrinn10",
+  "tittel": [
+    {
+      "spraak": "http://data.udir.no/kl06/v201906/spraak/nob",
+      "verdi": "Tiende årstrinn"
+    },
+    {
+      "spraak": "default",
+      "verdi": "Tiende årstrinn"
+    }
+  ],
+  "grep-type": "http://psi.udir.no/ontologi/kl06/aarstrinn",
+  "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+  "rekkefoelge": 10
+}

--- a/eksempler/fagtype/felles_programfag.json
+++ b/eksempler/fagtype/felles_programfag.json
@@ -1,0 +1,35 @@
+{
+  "id": "http://psi.udir.no/ontologi/felles_programfag",
+  "kode": "fagtype_felles_programfag",
+  "uri": "http://psi.udir.no/kl06/fagtype_felles_programfag",
+  "url-data": "http://data.udir.no/kl06/v201906/fagtype/fagtype_felles_programfag",
+  "tittel": [
+    {
+      "spraak": "http://data.udir.no/kl06/v201906/spraak/nob",
+      "verdi": "Felles programfag"
+    },
+    {
+      "spraak": "default",
+      "verdi": "Felles programfag"
+    }
+  ],
+  "grep-type": "http://psi.udir.no/ontologi/kl06/fagtype",
+  "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+  "rekkefoelge": 4,
+  "opplaeringsnivaa": {
+    "kode": "opplaeringsnivaa_videregaaende",
+    "uri": "http://psi.udir.no/kl06/opplaeringsnivaa_videregaaende",
+    "url-data": "http://data.udir.no/kl06/v201906/opplaeringsnivaa/opplaeringsnivaa_videregaaende",
+    "tittel": "Videregående opplæring"
+  },
+  "kortform": [
+    {
+      "spraak": "default",
+      "verdi": "FP"
+    },
+    {
+      "spraak": "http://data.udir.no/kl06/v201906/spraak/nob",
+      "verdi": "FP"
+    }
+  ]
+}

--- a/eksempler/opplaeringsnivaa/opplaeringsnivaa_grunnskole.json
+++ b/eksempler/opplaeringsnivaa/opplaeringsnivaa_grunnskole.json
@@ -1,0 +1,27 @@
+{
+  "id": "http://psi.udir.no/ontologi/opplaeringsnivaa_grunnskole",
+  "kode": "opplaeringsnivaa_grunnskole",
+  "uri": "http://psi.udir.no/kl06/opplaeringsnivaa_grunnskole",
+  "url-data": "http://data.udir.no/kl06/v201906/opplaeringsnivaa/opplaeringsnivaa_grunnskole",
+  "tittel": [
+    {
+      "spraak": "http://data.udir.no/kl06/v201906/spraak/eng",
+      "verdi": "Primary and lower secondary education"
+    },
+    {
+      "spraak": "http://data.udir.no/kl06/v201906/spraak/nno",
+      "verdi": "Grunnskule"
+    },
+    {
+      "spraak": "http://data.udir.no/kl06/v201906/spraak/nob",
+      "verdi": "Grunnskole"
+    },
+    {
+      "spraak": "default",
+      "verdi": "Grunnskole"
+    }
+  ],
+  "grep-type": "http://psi.udir.no/ontologi/kl06/opplaeringsnivaa",
+  "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+  "rekkefoelge": 1
+}

--- a/eksempler/spraak/nob.json
+++ b/eksempler/spraak/nob.json
@@ -1,0 +1,23 @@
+{
+    "id": "http://psi.oasis-open.org/iso/639/#nob",
+    "kode": "nob",
+    "uri": "http://psi.udir.no/kl06/nob",
+    "url-data": "http://data.udir.no/kl06/v201906/spraak/nob",
+    "tittel": [
+      {
+        "spraak": "http://data.udir.no/kl06/v201906/spraak/nob",
+        "verdi": "Bokmål"
+      },
+      {
+        "spraak": "http://data.udir.no/kl06/v201906/spraak/nno",
+        "verdi": "Bokmål"
+      },
+      {
+        "spraak": "default",
+        "verdi": "Bokmål"
+      }
+    ],
+    "grep-type": "http://psi.udir.no/ontologi/kl06/spraak",
+    "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
+    "rekkefoelge": 1
+  }


### PR DESCRIPTION
Status og rekkefølge legges til som attributter på grep-typene:
- årstrinn
- fagtype
- opplæringsnivå
- språk