### PR TITLE
Tatt bort kompetansemål- og læreplanreferanser på grf, tt, ke og verb

### DIFF
--- a/eksempler/grunnleggende-ferdigheter/GF1.json
+++ b/eksempler/grunnleggende-ferdigheter/GF1.json
@@ -13,35 +13,5 @@
     "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
     "sist-endret": "2018-12-21T13:16:05.228885",
     "lenke-til-beskrivelse": "https://www.udir.no/laring-og-trivsel/lareplanverket/grunnleggende-ferdigheter/rammeverk-for-grunnleggende-ferdigheter/2.1-digitale-ferdigheter/",
-    "rekkefoelge": 1,
-    "laereplan-referanser": [
-        {
-            "gyldighet": {
-                "gyldig-fra": null,
-                "gyldig-til": null
-            },
-            "id": "uuid:3c03c709-4934-4012-9353-c14bfa8ff651",
-            "kode": "MAT1-05",
-            "uri": "http://psi.udir.no/kl06/MAT1-05",
-            "url-data": "http://data.udir.no/kl06/v201906/laereplaner-lk20/MAT1-05",
-            "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
-            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
-            "tittel": "Matematikk fellesfag"
-        }
-    ],
-    "kompetansemaal-referanser": [
-        {
-            "gyldighet": {
-                "gyldig-fra": null,
-                "gyldig-til": null
-            },
-            "id": "uuid:cec30cd4-1fe6-11e9-8e78-d663bd873d93",
-            "kode": "K1",
-            "uri": "http://psi.udir.no/kl06/K1",
-            "url-data": "http://data.udir.no/kl06/v201906/kompetansemaal-lk20/K1",
-            "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
-            "tittel": "samanlikne ulike storleikar og mengder og uttrykkje dette gjennom eige språk og matematisk språk"
-        }
-    ]
+    "rekkefoelge": 1
 }

--- a/eksempler/kjerneelementer/KE1.json
+++ b/eksempler/kjerneelementer/KE1.json
@@ -43,20 +43,5 @@
         "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
         "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
         "tittel": "Matematikk fellesfag"
-    },
-    "kompetansemaal-referanser": [
-        {
-            "gyldighet": {
-                "gyldig-fra": null,
-                "gyldig-til": null
-            },
-            "id": "uuid:cec30cd4-1fe6-11e9-8e78-d663bd873d93",
-            "kode": "K1",
-            "uri": "http://psi.udir.no/kl06/K1",
-            "url-data": "http://data.udir.no/kl06/v201906/kompetansemaal-lk20/K1",
-            "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
-            "tittel": "samanlikne ulike storleikar og mengder og uttrykkje dette gjennom eige språk og matematisk språk"
-        }
-    ]
+    }
 }

--- a/eksempler/tverrfaglige-temaer/TT1.json
+++ b/eksempler/tverrfaglige-temaer/TT1.json
@@ -13,35 +13,5 @@
     "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
     "sist-endret": "2018-12-19T13:16:05.228885",
     "lenke-til-beskrivelse": "https://www.udir.no/laring-og-trivsel/lareplanverket/overordnet-del/prinsipper-for-laring-utvikling-og-danning/tverrfaglige-temaer/folkehelse-og-livsmestring/",
-    "rekkefoelge": 1,
-    "laereplan-referanser": [
-        {
-            "gyldighet": {
-                "gyldig-fra": null,
-                "gyldig-til": null
-            },
-            "id": "uuid:3c03c709-4934-4012-9353-c14bfa8ff651",
-            "kode": "MAT1-05",
-            "uri": "http://psi.udir.no/kl06/MAT1-05",
-            "url-data": "http://data.udir.no/kl06/v201906/laereplaner-lk20/MAT1-05",
-            "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
-            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
-            "tittel": "Matematikk fellesfag"
-        }
-    ],
-    "kompetansemaal-referanser": [
-        {
-            "gyldighet": {
-                "gyldig-fra": null,
-                "gyldig-til": null
-            },
-            "id": "uuid:cec30cd4-1fe6-11e9-8e78-d663bd873d93",
-            "kode": "K1",
-            "uri": "http://psi.udir.no/kl06/K1",
-            "url-data": "http://data.udir.no/kl06/v201906/kompetansemaal-lk20/K1",
-            "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
-            "tittel": "samanlikne ulike storleikar og mengder og uttrykkje dette gjennom eige språk og matematisk språk"
-        }
-    ]
+    "rekkefoelge": 1
 }

--- a/eksempler/verb/VERB14.json
+++ b/eksempler/verb/VERB14.json
@@ -19,19 +19,5 @@
         }
     ],
     "globalt-verb": true,
-    "kompetansemaal-referanser": [
-        {
-            "gyldighet": {
-                "gyldig-fra": null,
-                "gyldig-til": null
-            },
-            "id": "uuid:cec30cd4-1fe6-11e9-8e78-d663bd873d93",
-            "kode": "K1",
-            "uri": "http://psi.udir.no/kl06/K1",
-            "url-data": "http://data.udir.no/kl06/v201906/kompetansemaal-lk20/K1",
-            "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
-            "tittel": "samanlikne ulike storleikar og mengder og uttrykkje dette gjennom eige språk og matematisk språk"
-        }
-    ]
+    "tilhoerer-laereplan": null
 }

--- a/eksempler/verb/VERB20.json
+++ b/eksempler/verb/VERB20.json
@@ -31,20 +31,5 @@
         "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
         "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
         "tittel": "Matematikk fellesfag"
-    },
-    "kompetansemaal-referanser": [
-        {
-            "gyldighet": {
-                "gyldig-fra": null,
-                "gyldig-til": null
-            },
-            "id": "uuid:6026d4f6-2e26-11e9-b210-d663bd873d93",
-            "kode": "K4",
-            "uri": "http://psi.udir.no/kl06/K4",
-            "url-data": "http://data.udir.no/kl06/v201906/kompetansemaal-lk20/K4",
-            "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-            "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
-            "tittel": "tyde og utforske mønster og tal"
-        }
-    ]
+    }
 }

--- a/eksempler/verb/verb.json
+++ b/eksempler/verb/verb.json
@@ -20,7 +20,7 @@
             }
         ],
         "globalt-verb": true,
-        "kompetansemaal-referanser": []
+        "tilhoerer-laereplan": null
     },
     {
         "id": "uuid:919b0d5e-fd4d-11e8-8eb2-f2801f1b9fd1",
@@ -43,7 +43,7 @@
             }
         ],
         "globalt-verb": true,
-        "kompetansemaal-referanser": []
+        "tilhoerer-laereplan": null
     },
     {
         "id": "uuid:9e5bf116-fd4d-11e8-8eb2-f2801f1b9fd1",
@@ -66,7 +66,7 @@
             }
         ],
         "globalt-verb": true,
-        "kompetansemaal-referanser": []
+        "tilhoerer-laereplan": null
     },
     {
         "id": "uuid:cce555ae-fd4d-11e8-8eb2-f2801f1b9fd1",
@@ -89,7 +89,7 @@
             }
         ],
         "globalt-verb": true,
-        "kompetansemaal-referanser": []
+        "tilhoerer-laereplan": null
     },
     {
         "id": "uuid:fa0fdbbc-fd4d-11e8-8eb2-f2801f1b9fd1",
@@ -112,7 +112,7 @@
             }
         ],
         "globalt-verb": true,
-        "kompetansemaal-referanser": []
+        "tilhoerer-laereplan": null
     },
     {
         "id": "uuid:2d352808-fd4e-11e8-8eb2-f2801f1b9fd1",
@@ -135,7 +135,7 @@
             }
         ],
         "globalt-verb": true,
-        "kompetansemaal-referanser": []
+        "tilhoerer-laereplan": null
     },
     {
         "id": "uuid:871be6a8-fd4f-11e8-8eb2-f2801f1b9fd1",
@@ -158,7 +158,7 @@
             }
         ],
         "globalt-verb": true,
-        "kompetansemaal-referanser": []
+        "tilhoerer-laereplan": null
     },
     {
         "id": "uuid:4c84d43a-fd51-11e8-8eb2-f2801f1b9fd1",
@@ -181,7 +181,7 @@
             }
         ],
         "globalt-verb": true,
-        "kompetansemaal-referanser": []
+        "tilhoerer-laereplan": null
     },
     {
         "id": "uuid:91eaaf04-fd51-11e8-8eb2-f2801f1b9fd1",
@@ -204,7 +204,7 @@
             }
         ],
         "globalt-verb": true,
-        "kompetansemaal-referanser": []
+        "tilhoerer-laereplan": null
     },
     {
         "id": "uuid:b79b6dec-fd51-11e8-8eb2-f2801f1b9fd1",
@@ -227,7 +227,7 @@
             }
         ],
         "globalt-verb": true,
-        "kompetansemaal-referanser": []
+        "tilhoerer-laereplan": null
     },
     {
         "id": "uuid:d64a693c-fd51-11e8-8eb2-f2801f1b9fd1",
@@ -250,7 +250,7 @@
             }
         ],
         "globalt-verb": true,
-        "kompetansemaal-referanser": []
+        "tilhoerer-laereplan": null
     },
     {
         "id": "uuid:eb5bf6a6-fd51-11e8-8eb2-f2801f1b9fd1",
@@ -273,7 +273,7 @@
             }
         ],
         "globalt-verb": true,
-        "kompetansemaal-referanser": []
+        "tilhoerer-laereplan": null
     },
     {
         "id": "uuid:304a18d8-fd52-11e8-8eb2-f2801f1b9fd1",
@@ -296,7 +296,7 @@
             }
         ],
         "globalt-verb": true,
-        "kompetansemaal-referanser": []
+        "tilhoerer-laereplan": null
     },
     {
         "id": "uuid:859ec978-fd4d-11e8-8eb2-f2801f1b9fd1",
@@ -319,21 +319,7 @@
             }
         ],
         "globalt-verb": true,
-        "kompetansemaal-referanser": [
-            {
-                "gyldighet": {
-                    "gyldig-fra": null,
-                    "gyldig-til": null
-                },
-                "id": "uuid:cec30cd4-1fe6-11e9-8e78-d663bd873d93",
-                "kode": "K1",
-                "uri": "http://psi.udir.no/kl06/K1",
-                "url-data": "http://data.udir.no/kl06/v201906/kompetansemaal-lk20/K1",
-                "grep-type": "http://psi.udir.no/ontologi/kl06/kompetansemaal_lk20",
-                "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
-                "tittel": "samanlikne ulike storleikar og mengder og uttrykkje dette gjennom eige språk og matematisk språk"
-            }
-        ]
+        "tilhoerer-laereplan": null
     },
     {
         "id": "uuid:5f6a1d20-fd52-11e8-8eb2-f2801f1b9fd1",
@@ -356,7 +342,7 @@
             }
         ],
         "globalt-verb": true,
-        "kompetansemaal-referanser": []
+        "tilhoerer-laereplan": null
     },
     {
         "id": "uuid:78188a28-fd52-11e8-8eb2-f2801f1b9fd1 ",
@@ -379,7 +365,7 @@
             }
         ],
         "globalt-verb": true,
-        "kompetansemaal-referanser": []
+        "tilhoerer-laereplan": null
     },
     {
         "id": "uuid:b588c620-fd52-11e8-8eb2-f2801f1b9fd1",
@@ -402,7 +388,7 @@
             }
         ],
         "globalt-verb": true,
-        "kompetansemaal-referanser": []
+        "tilhoerer-laereplan": null
     },
     {
         "id": "uuid:da13369c-fd52-11e8-8eb2-f2801f1b9fd1",
@@ -425,7 +411,7 @@
             }
         ],
         "globalt-verb": true,
-        "kompetansemaal-referanser": []
+        "tilhoerer-laereplan": null
     },
     {
         "id": "uuid:bfc0d8a2-fe34-11e8-8eb2-f2801f1b9fd1",
@@ -460,8 +446,7 @@
             "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
             "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Matematikk fellesfag"
-        },
-        "kompetansemaal-referanser": []
+        }
     },
     {
         "id": "uuid:c42a4874-fe34-11e8-8eb2-f2801f1b9fd1",
@@ -496,7 +481,6 @@
             "grep-type": "http://psi.udir.no/ontologi/kl06/laereplan_lk20",
             "status": "http://data.udir.no/kl06/v201906/status/status_publisert",
             "tittel": "Matematikk fellesfag"
-        },
-        "kompetansemaal-referanser": []
+        }
     }
 ]


### PR DESCRIPTION
tilhører læreplan er lagt til på alle Verb (globale og lokale).